### PR TITLE
Change ECO  A41 King's Pawn Game: Maróczy Defense to B07

### DIFF
--- a/a.tsv
+++ b/a.tsv
@@ -467,7 +467,6 @@ A40	St. George Defense: Polish Variation	1. d4 b5 2. e4 a6 3. Nf3 Bb7 4. Bd3 e6
 A40	Zaire Defense	1. d4 Nc6 2. d5 Nb8 3. e4 Nf6 4. e5 Ng8
 A40	Zukertort Defense: Kingside Variation	1. d4 g6 2. Nf3 Nh6
 A41	English Rat: Pounds Gambit	1. d4 d6 2. c4 e5 3. dxe5 Be6
-A41	King's Pawn Game: Maróczy Defense	1. d4 d6 2. e4 e5
 A41	Modern Defense	1. d4 g6 2. c4 Bg7 3. Nc3 d6
 A41	Old Indian Defense	1. d4 d6 2. c4
 A41	Queen's Pawn Game	1. d4 d6

--- a/b.tsv
+++ b/b.tsv
@@ -224,6 +224,7 @@ B06	Pterodactyl Defense: Western, Anhanguera	1. e4 g6 2. d4 Bg7 3. Nf3 c5 4. Be3
 B06	Pterodactyl Defense: Western, Siroccopteryx	1. e4 g6 2. Nf3 Bg7 3. d4 c5 4. Bc4 cxd4 5. Nxd4 Qa5+
 B06	Rat Defense: Accelerated Gurgenidze	1. e4 g6 2. d4 d6 3. Nc3 c6
 B07	Czech Defense	1. e4 d6 2. d4 Nf6 3. Nc3 c6
+B07	King's Pawn Game: Maróczy Defense	1. d4 d6 2. e4 e5
 B07	Lion Defense: Anti-Philidor	1. e4 d6 2. d4 Nf6 3. Nc3 Nbd7 4. f4
 B07	Lion Defense: Anti-Philidor, Lion's Cave	1. e4 d6 2. d4 Nf6 3. Nc3 Nbd7 4. f4 e5
 B07	Lion Defense: Anti-Philidor, Lion's Cave, Lion Claw Gambit	1. e4 d6 2. d4 Nf6 3. Nc3 Nbd7 4. f4 e5 5. Nf3 exd4 6. Qxd4 c6 7. Bc4 d5

--- a/dist/a.tsv
+++ b/dist/a.tsv
@@ -467,7 +467,6 @@ A40	St. George Defense: Polish Variation	1. d4 b5 2. e4 a6 3. Nf3 Bb7 4. Bd3 e6	
 A40	Zaire Defense	1. d4 Nc6 2. d5 Nb8 3. e4 Nf6 4. e5 Ng8	d2d4 b8c6 d4d5 c6b8 e2e4 g8f6 e4e5 f6g8	rnbqkbnr/pppppppp/8/3PP3/8/8/PPP2PPP/RNBQKBNR w KQkq -
 A40	Zukertort Defense: Kingside Variation	1. d4 g6 2. Nf3 Nh6	d2d4 g7g6 g1f3 g8h6	rnbqkb1r/pppppp1p/6pn/8/3P4/5N2/PPP1PPPP/RNBQKB1R w KQkq -
 A41	English Rat: Pounds Gambit	1. d4 d6 2. c4 e5 3. dxe5 Be6	d2d4 d7d6 c2c4 e7e5 d4e5 c8e6	rn1qkbnr/ppp2ppp/3pb3/4P3/2P5/8/PP2PPPP/RNBQKBNR w KQkq -
-A41	King's Pawn Game: Maróczy Defense	1. d4 d6 2. e4 e5	d2d4 d7d6 e2e4 e7e5	rnbqkbnr/ppp2ppp/3p4/4p3/3PP3/8/PPP2PPP/RNBQKBNR w KQkq -
 A41	Modern Defense	1. d4 g6 2. c4 Bg7 3. Nc3 d6	d2d4 g7g6 c2c4 f8g7 b1c3 d7d6	rnbqk1nr/ppp1ppbp/3p2p1/8/2PP4/2N5/PP2PPPP/R1BQKBNR w KQkq -
 A41	Old Indian Defense	1. d4 d6 2. c4	d2d4 d7d6 c2c4	rnbqkbnr/ppp1pppp/3p4/8/2PP4/8/PP2PPPP/RNBQKBNR b KQkq -
 A41	Queen's Pawn Game	1. d4 d6	d2d4 d7d6	rnbqkbnr/ppp1pppp/3p4/8/3P4/8/PPP1PPPP/RNBQKBNR w KQkq -

--- a/dist/b.tsv
+++ b/dist/b.tsv
@@ -224,6 +224,7 @@ B06	Pterodactyl Defense: Western, Anhanguera	1. e4 g6 2. d4 Bg7 3. Nf3 c5 4. Be3
 B06	Pterodactyl Defense: Western, Siroccopteryx	1. e4 g6 2. Nf3 Bg7 3. d4 c5 4. Bc4 cxd4 5. Nxd4 Qa5+	e2e4 g7g6 g1f3 f8g7 d2d4 c7c5 f1c4 c5d4 f3d4 d8a5	rnb1k1nr/pp1pppbp/6p1/q7/2BNP3/8/PPP2PPP/RNBQK2R w KQkq -
 B06	Rat Defense: Accelerated Gurgenidze	1. e4 g6 2. d4 d6 3. Nc3 c6	e2e4 g7g6 d2d4 d7d6 b1c3 c7c6	rnbqkbnr/pp2pp1p/2pp2p1/8/3PP3/2N5/PPP2PPP/R1BQKBNR w KQkq -
 B07	Czech Defense	1. e4 d6 2. d4 Nf6 3. Nc3 c6	e2e4 d7d6 d2d4 g8f6 b1c3 c7c6	rnbqkb1r/pp2pppp/2pp1n2/8/3PP3/2N5/PPP2PPP/R1BQKBNR w KQkq -
+B07	King's Pawn Game: Maróczy Defense	1. d4 d6 2. e4 e5	d2d4 d7d6 e2e4 e7e5	rnbqkbnr/ppp2ppp/3p4/4p3/3PP3/8/PPP2PPP/RNBQKBNR w KQkq -
 B07	Lion Defense: Anti-Philidor	1. e4 d6 2. d4 Nf6 3. Nc3 Nbd7 4. f4	e2e4 d7d6 d2d4 g8f6 b1c3 b8d7 f2f4	r1bqkb1r/pppnpppp/3p1n2/8/3PPP2/2N5/PPP3PP/R1BQKBNR b KQkq -
 B07	Lion Defense: Anti-Philidor, Lion's Cave	1. e4 d6 2. d4 Nf6 3. Nc3 Nbd7 4. f4 e5	e2e4 d7d6 d2d4 g8f6 b1c3 b8d7 f2f4 e7e5	r1bqkb1r/pppn1ppp/3p1n2/4p3/3PPP2/2N5/PPP3PP/R1BQKBNR w KQkq -
 B07	Lion Defense: Anti-Philidor, Lion's Cave, Lion Claw Gambit	1. e4 d6 2. d4 Nf6 3. Nc3 Nbd7 4. f4 e5 5. Nf3 exd4 6. Qxd4 c6 7. Bc4 d5	e2e4 d7d6 d2d4 g8f6 b1c3 b8d7 f2f4 e7e5 g1f3 e5d4 d1d4 c7c6 f1c4 d6d5	r1bqkb1r/pp1n1ppp/2p2n2/3p4/2BQPP2/2N2N2/PPP3PP/R1B1K2R w KQkq -


### PR DESCRIPTION
https://old.chesstempo.com/gamedb/opening/980 mentions as King's Pawn Opening as parent
https://www.chess.com/openings/Pirc-Defense-Maroczy-Defense mentions it as Pirc Defense as parent
