### PR TITLE
Fixes #46

### DIFF
--- a/a.tsv
+++ b/a.tsv
@@ -307,7 +307,6 @@ A13	English Opening: Agincourt Defense, Wimpy System	1. Nf3 Nf6 2. c4 e6 3. b3 d
 A13	English Opening: Neo-Catalan	1. Nf3 Nf6 2. c4 e6 3. g3 d5
 A13	English Opening: Neo-Catalan Declined	1. Nf3 Nf6 2. c4 e6 3. g3 d5 4. Bg2 Be7
 A13	English Opening: Romanishin Gambit	1. Nf3 Nf6 2. c4 e6 3. g3 a6 4. Bg2 b5
-A13	Horwitz Defense: Zilbermints Gambit	1. d4 e6 2. e4 e5
 A14	English Opening: Agincourt Defense, Keres Defense	1. c4 c5 2. Nf3 Nf6 3. Nc3 e6 4. g3 d5 5. cxd5 Nxd5 6. Bg2 Nc6 7. O-O Be7
 A14	English Opening: Agincourt Defense, Neo-Catalan Declined	1. Nf3 Nf6 2. c4 e6 3. g3 d5 4. Bg2 Be7 5. O-O
 A14	Réti Opening: Anglo-Slav Variation, Bogoljubov Variation, Stonewall Line	1. Nf3 d5 2. c4 e6 3. g3 Nf6 4. Bg2 Be7 5. O-O O-O 6. b3 c6 7. Bb2
@@ -439,6 +438,7 @@ A40	Englund Gambit Declined: Reversed Brooklyn	1. d4 e5 2. Nf3 e4 3. Ng1
 A40	Englund Gambit Declined: Reversed Krebs	1. d4 e5 2. Nf3 e4
 A40	Englund Gambit Declined: Reversed Mokele Mbembe	1. d4 e5 2. Nf3 e4 3. Ne5
 A40	Horwitz Defense	1. d4 e6
+A40	Horwitz Defense: Zilbermints Gambit	1. d4 e6 2. c4 e5
 A40	Kangaroo Defense	1. d4 e6 2. c4 Bb4+
 A40	Kangaroo Defense: Keres Defense, Transpositional Variation	1. d4 e6 2. c4 Bb4+ 3. Nc3
 A40	Mikenas Defense	1. d4 Nc6

--- a/a.tsv
+++ b/a.tsv
@@ -307,7 +307,7 @@ A13	English Opening: Agincourt Defense, Wimpy System	1. Nf3 Nf6 2. c4 e6 3. b3 d
 A13	English Opening: Neo-Catalan	1. Nf3 Nf6 2. c4 e6 3. g3 d5
 A13	English Opening: Neo-Catalan Declined	1. Nf3 Nf6 2. c4 e6 3. g3 d5 4. Bg2 Be7
 A13	English Opening: Romanishin Gambit	1. Nf3 Nf6 2. c4 e6 3. g3 a6 4. Bg2 b5
-A13	Horwitz Defense: Zilbermints Gambit	1. c4 e6 2. d4 e5
+A13	Horwitz Defense: Zilbermints Gambit	1. d4 e6 2. e4 e5
 A14	English Opening: Agincourt Defense, Keres Defense	1. c4 c5 2. Nf3 Nf6 3. Nc3 e6 4. g3 d5 5. cxd5 Nxd5 6. Bg2 Nc6 7. O-O Be7
 A14	English Opening: Agincourt Defense, Neo-Catalan Declined	1. Nf3 Nf6 2. c4 e6 3. g3 d5 4. Bg2 Be7 5. O-O
 A14	Réti Opening: Anglo-Slav Variation, Bogoljubov Variation, Stonewall Line	1. Nf3 d5 2. c4 e6 3. g3 Nf6 4. Bg2 Be7 5. O-O O-O 6. b3 c6 7. Bb2
@@ -683,11 +683,11 @@ A83	Dutch Defense: Staunton Gambit, Chigorin Variation	1. d4 f5 2. e4 fxe4 3. Nc
 A83	Dutch Defense: Staunton Gambit, Lasker Variation	1. d4 f5 2. e4 fxe4 3. Nc3 Nf6 4. Bg5 g6 5. f3
 A83	Dutch Defense: Staunton Gambit, Nimzowitsch Variation	1. d4 f5 2. e4 fxe4 3. Nc3 Nf6 4. Bg5 b6
 A84	Dutch Defense	1. d4 f5 2. c4
+A84	Dutch Defense: Bellon Gambit	1. d4 f5 2. c4 e6 3. e4
 A84	Dutch Defense: Bladel Variation	1. d4 f5 2. c4 g6 3. Nc3 Nh6
 A84	Dutch Defense: Classical Variation	1. d4 e6 2. c4 f5
 A84	Dutch Defense: Normal Variation	1. d4 f5 2. c4 Nf6
-A84	Dutch Defense: Rubinstein Variation	1. d4 e6 2. c4 f5 3. Nc3
-A84	Horwitz Defense: Dutch Defense, Bellon Gambit	1. d4 e6 2. c4 f5 3. e4
+A84	Dutch Defense: Rubinstein Variation	1. d4 f5 2. c4 e6 3. Nc3
 A85	Dutch Defense: Queen's Knight Variation	1. d4 f5 2. c4 Nf6 3. Nc3
 A86	Dutch Defense: Fianchetto Variation	1. d4 f5 2. c4 Nf6 3. g3
 A86	Dutch Defense: Hort-Antoshin System	1. c4 f5 2. g3 Nf6 3. Bg2 d6 4. Nc3 c6 5. d4 Qc7

--- a/b.tsv
+++ b/b.tsv
@@ -231,7 +231,6 @@ B07	Lion Defense: Anti-Philidor, Lion's Cave, Lion Claw Gambit	1. e4 d6 2. d4 Nf
 B07	Lion Defense: Bayonet Attack	1. e4 d6 2. d4 Nf6 3. Nc3 Nbd7 4. g4
 B07	Modern Defense: Geller's System	1. e4 g6 2. d4 Bg7 3. Nf3 d6 4. c3
 B07	Philidor Defense: Lion Variation, Lion's Claw	1. e4 d6 2. d4 Nf6 3. Nc3 c6 4. Be2 Nbd7 5. Nf3 e5 6. O-O Be7
-B07	Pirc Defense	1. e4 d6 2. d4 Nf6 3. Nc3
 B07	Pirc Defense	1. e4 d6 2. d4 Nf6 3. Nc3 g6
 B07	Pirc Defense: 150 Attack	1. e4 d6 2. d4 Nf6 3. Nc3 g6 4. Be3 c6 5. Qd2
 B07	Pirc Defense: 150 Attack, Inner Doll Defense	1. e4 d6 2. d4 Nf6 3. Nc3 g6 4. Be3 c6 5. Qd2 Bg4

--- a/c.tsv
+++ b/c.tsv
@@ -352,8 +352,8 @@ C30	King's Gambit Declined: Petrov's Defense	1. e4 e5 2. f4 Nf6
 C30	King's Gambit Declined: Queen's Knight Defense	1. e4 e5 2. f4 Nc6
 C30	King's Gambit Declined: Senechaud Countergambit	1. e4 e5 2. f4 Bc5 3. Nf3 g5
 C30	King's Gambit Declined: Soller-Zilbermints Gambit	1. e4 e5 2. f4 f6 3. fxe5 Nc6
+C30	King's Gambit Declined: Zilbermints Double Countergambit	1. e4 e5 2. f4 g5
 C30	King's Gambit Declined: Zilbermints Double Gambit	1. e4 e5 2. f4 Nc6 3. Nf3 g5
-C30	King's Gambit: Zilbermints Double Countergambit	1. e4 e5 2. f4 g5
 C31	King's Gambit Declined: Falkbeer Countergambit	1. e4 e5 2. f4 d5
 C31	King's Gambit Declined: Falkbeer Countergambit Accepted	1. e4 e5 2. f4 d5 3. exd5
 C31	King's Gambit Declined: Falkbeer Countergambit, Anderssen Attack	1. e4 e5 2. f4 d5 3. exd5 e4 4. Bb5+

--- a/d.tsv
+++ b/d.tsv
@@ -1,6 +1,6 @@
 eco	name	pgn
 D00	Amazon Attack	1. d4 d5 2. Qd3
-D00	Blackmar Gambit	1. d4 d5 2. e4
+D00	Blackmar-Diemer Gambit	1. d4 d5 2. e4
 D00	Blackmar-Diemer Gambit	1. d4 d5 2. e4 dxe4 3. Nc3
 D00	Blackmar-Diemer Gambit	1. d4 Nf6 2. Nc3 d5 3. e4
 D00	Blackmar-Diemer Gambit Declined: Brombacher Countergambit	1. d4 Nf6 2. Nc3 d5 3. e4 dxe4 4. f3 c5
@@ -19,6 +19,7 @@ D00	Blackmar-Diemer Gambit: Euwe Defense, Zilbermints Gambit	1. d4 d5 2. e4 dxe4
 D00	Blackmar-Diemer Gambit: Fritz Attack	1. d4 d5 2. e4 dxe4 3. Bc4
 D00	Blackmar-Diemer Gambit: Gedult Gambit	1. d4 d5 2. e4 dxe4 3. f3
 D00	Blackmar-Diemer Gambit: Kaulich Defense	1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. f3 exf3 5. Nxf3 c5
+D00	Blackmar-Diemer Gambit: Lemberger Countergambit	1. d4 d5 2. Nc3 Nf6 3. e4 e5
 D00	Blackmar-Diemer Gambit: Lemberger Countergambit, Diemer Attack	1. d4 d5 2. e4 dxe4 3. Nc3 e5 4. Be3
 D00	Blackmar-Diemer Gambit: Lemberger Countergambit, Endgame Variation	1. d4 d5 2. e4 dxe4 3. Nc3 e5 4. dxe5
 D00	Blackmar-Diemer Gambit: Lemberger Countergambit, Rassmussen Attack	1. d4 d5 2. e4 dxe4 3. Nc3 e5 4. Nge2
@@ -39,7 +40,6 @@ D00	Blackmar-Diemer Gambit: Zeller Defense, Soller Attack	1. d4 d5 2. e4 dxe4 3.
 D00	Blackmar-Diemer Gambit: Ziegler Defense	1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. f3 exf3 5. Nxf3 c6
 D00	Blackmar-Diemer Gambit: von Popiel Gambit	1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. Bg5
 D00	Blackmar-Diemer Gambit: von Popiel Gambit, Zilbermints Variation	1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. Bg5 Bf5 5. Bxf6 exf6 6. g4 Bg6 7. Qe2 Bb4 8. Qb5+
-D00	Blackmar-Diemer, Lemberger Countergambit	1. d4 d5 2. Nc3 Nf6 3. e4 e5
 D00	Queen's Pawn Game	1. d4 d5
 D00	Queen's Pawn Game	1. d4 d5 2. e3
 D00	Queen's Pawn Game	1. d4 d5 2. e3 Nf6
@@ -287,10 +287,10 @@ D34	Tarrasch Defense: Classical Variation, Réti Variation	1. d4 d5 2. c4 e6 3. 
 D34	Tarrasch Defense: Classical Variation, Spassky Variation	1. d4 d5 2. c4 e6 3. Nc3 c5 4. cxd5 exd5 5. Nf3 Nc6 6. g3 Nf6 7. Bg2 Be7 8. O-O O-O 9. Bg5 cxd4 10. Nxd4 h6 11. Be3 Bg4
 D34	Tarrasch Defense: Prague Variation, Main Line	1. d4 d5 2. c4 e6 3. Nc3 c5 4. cxd5 exd5 5. Nf3 Nc6 6. g3 Nf6 7. Bg2 Be7
 D35	Queen's Gambit Declined: Exchange Variation	1. d4 Nf6 2. c4 e6 3. Nc3 d5 4. cxd5
+D35	Queen's Gambit Declined: Exchange Variation, Chameleon Variation	1. d4 Nf6 2. c4 e6 3. Nc3 d5 4. cxd5 exd5 5. Bg5 Be7 6. e3 O-O 7. Bd3 Nbd7 8. Qc2 Re8 9. Nge2 Nf8 10. O-O-O
 D35	Queen's Gambit Declined: Exchange Variation, Positional Variation	1. d4 Nf6 2. c4 e6 3. Nc3 d5 4. cxd5 exd5 5. Bg5
 D35	Queen's Gambit Declined: Exchange Variation, Positional Variation	1. d4 Nf6 2. c4 e6 3. Nc3 d5 4. cxd5 exd5 5. Bg5 c6
 D35	Queen's Gambit Declined: Exchange Variation, Sämisch Variation	1. d4 Nf6 2. c4 e6 3. Nf3 d5 4. Nc3 Nbd7 5. cxd5 exd5 6. Bf4
-D35	Queen's Gambit Declined: Exchange, Chameleon Variation	1. d4 Nf6 2. c4 e6 3. Nc3 d5 4. cxd5 exd5 5. Bg5 Be7 6. e3 O-O 7. Bd3 Nbd7 8. Qc2 Re8 9. Nge2 Nf8 10. O-O-O
 D35	Queen's Gambit Declined: Harrwitz Attack	1. d4 d5 2. c4 e6 3. Nc3 Nf6 4. Bf4
 D35	Queen's Gambit Declined: Normal Defense	1. d4 d5 2. c4 e6 3. Nc3 Nf6
 D36	Queen's Gambit Declined: Exchange Variation, Reshevsky Variation	1. d4 Nf6 2. c4 e6 3. Nc3 d5 4. cxd5 exd5 5. Bg5 c6 6. Qc2

--- a/dist/a.tsv
+++ b/dist/a.tsv
@@ -307,7 +307,7 @@ A13	English Opening: Agincourt Defense, Wimpy System	1. Nf3 Nf6 2. c4 e6 3. b3 d
 A13	English Opening: Neo-Catalan	1. Nf3 Nf6 2. c4 e6 3. g3 d5	g1f3 g8f6 c2c4 e7e6 g2g3 d7d5	rnbqkb1r/ppp2ppp/4pn2/3p4/2P5/5NP1/PP1PPP1P/RNBQKB1R w KQkq -
 A13	English Opening: Neo-Catalan Declined	1. Nf3 Nf6 2. c4 e6 3. g3 d5 4. Bg2 Be7	g1f3 g8f6 c2c4 e7e6 g2g3 d7d5 f1g2 f8e7	rnbqk2r/ppp1bppp/4pn2/3p4/2P5/5NP1/PP1PPPBP/RNBQK2R w KQkq -
 A13	English Opening: Romanishin Gambit	1. Nf3 Nf6 2. c4 e6 3. g3 a6 4. Bg2 b5	g1f3 g8f6 c2c4 e7e6 g2g3 a7a6 f1g2 b7b5	rnbqkb1r/2pp1ppp/p3pn2/1p6/2P5/5NP1/PP1PPPBP/RNBQK2R w KQkq -
-A13	Horwitz Defense: Zilbermints Gambit	1. c4 e6 2. d4 e5	c2c4 e7e6 d2d4 e6e5	rnbqkbnr/pppp1ppp/8/4p3/2PP4/8/PP2PPPP/RNBQKBNR w KQkq -
+A13	Horwitz Defense: Zilbermints Gambit	1. d4 e6 2. e4 e5	d2d4 e7e6 e2e4 e6e5	rnbqkbnr/pppp1ppp/8/4p3/3PP3/8/PPP2PPP/RNBQKBNR w KQkq -
 A14	English Opening: Agincourt Defense, Keres Defense	1. c4 c5 2. Nf3 Nf6 3. Nc3 e6 4. g3 d5 5. cxd5 Nxd5 6. Bg2 Nc6 7. O-O Be7	c2c4 c7c5 g1f3 g8f6 b1c3 e7e6 g2g3 d7d5 c4d5 f6d5 f1g2 b8c6 e1g1 f8e7	r1bqk2r/pp2bppp/2n1p3/2pn4/8/2N2NP1/PP1PPPBP/R1BQ1RK1 w kq -
 A14	English Opening: Agincourt Defense, Neo-Catalan Declined	1. Nf3 Nf6 2. c4 e6 3. g3 d5 4. Bg2 Be7 5. O-O	g1f3 g8f6 c2c4 e7e6 g2g3 d7d5 f1g2 f8e7 e1g1	rnbqk2r/ppp1bppp/4pn2/3p4/2P5/5NP1/PP1PPPBP/RNBQ1RK1 b kq -
 A14	Réti Opening: Anglo-Slav Variation, Bogoljubov Variation, Stonewall Line	1. Nf3 d5 2. c4 e6 3. g3 Nf6 4. Bg2 Be7 5. O-O O-O 6. b3 c6 7. Bb2	g1f3 d7d5 c2c4 e7e6 g2g3 g8f6 f1g2 f8e7 e1g1 e8g8 b2b3 c7c6 c1b2	rnbq1rk1/pp2bppp/2p1pn2/3p4/2P5/1P3NP1/PB1PPPBP/RN1Q1RK1 b - -
@@ -683,11 +683,11 @@ A83	Dutch Defense: Staunton Gambit, Chigorin Variation	1. d4 f5 2. e4 fxe4 3. Nc
 A83	Dutch Defense: Staunton Gambit, Lasker Variation	1. d4 f5 2. e4 fxe4 3. Nc3 Nf6 4. Bg5 g6 5. f3	d2d4 f7f5 e2e4 f5e4 b1c3 g8f6 c1g5 g7g6 f2f3	rnbqkb1r/ppppp2p/5np1/6B1/3Pp3/2N2P2/PPP3PP/R2QKBNR b KQkq -
 A83	Dutch Defense: Staunton Gambit, Nimzowitsch Variation	1. d4 f5 2. e4 fxe4 3. Nc3 Nf6 4. Bg5 b6	d2d4 f7f5 e2e4 f5e4 b1c3 g8f6 c1g5 b7b6	rnbqkb1r/p1ppp1pp/1p3n2/6B1/3Pp3/2N5/PPP2PPP/R2QKBNR w KQkq -
 A84	Dutch Defense	1. d4 f5 2. c4	d2d4 f7f5 c2c4	rnbqkbnr/ppppp1pp/8/5p2/2PP4/8/PP2PPPP/RNBQKBNR b KQkq -
+A84	Dutch Defense: Bellon Gambit	1. d4 f5 2. c4 e6 3. e4	d2d4 f7f5 c2c4 e7e6 e2e4	rnbqkbnr/pppp2pp/4p3/5p2/2PPP3/8/PP3PPP/RNBQKBNR b KQkq -
 A84	Dutch Defense: Bladel Variation	1. d4 f5 2. c4 g6 3. Nc3 Nh6	d2d4 f7f5 c2c4 g7g6 b1c3 g8h6	rnbqkb1r/ppppp2p/6pn/5p2/2PP4/2N5/PP2PPPP/R1BQKBNR w KQkq -
 A84	Dutch Defense: Classical Variation	1. d4 e6 2. c4 f5	d2d4 e7e6 c2c4 f7f5	rnbqkbnr/pppp2pp/4p3/5p2/2PP4/8/PP2PPPP/RNBQKBNR w KQkq -
 A84	Dutch Defense: Normal Variation	1. d4 f5 2. c4 Nf6	d2d4 f7f5 c2c4 g8f6	rnbqkb1r/ppppp1pp/5n2/5p2/2PP4/8/PP2PPPP/RNBQKBNR w KQkq -
-A84	Dutch Defense: Rubinstein Variation	1. d4 e6 2. c4 f5 3. Nc3	d2d4 e7e6 c2c4 f7f5 b1c3	rnbqkbnr/pppp2pp/4p3/5p2/2PP4/2N5/PP2PPPP/R1BQKBNR b KQkq -
-A84	Horwitz Defense: Dutch Defense, Bellon Gambit	1. d4 e6 2. c4 f5 3. e4	d2d4 e7e6 c2c4 f7f5 e2e4	rnbqkbnr/pppp2pp/4p3/5p2/2PPP3/8/PP3PPP/RNBQKBNR b KQkq -
+A84	Dutch Defense: Rubinstein Variation	1. d4 f5 2. c4 e6 3. Nc3	d2d4 f7f5 c2c4 e7e6 b1c3	rnbqkbnr/pppp2pp/4p3/5p2/2PP4/2N5/PP2PPPP/R1BQKBNR b KQkq -
 A85	Dutch Defense: Queen's Knight Variation	1. d4 f5 2. c4 Nf6 3. Nc3	d2d4 f7f5 c2c4 g8f6 b1c3	rnbqkb1r/ppppp1pp/5n2/5p2/2PP4/2N5/PP2PPPP/R1BQKBNR b KQkq -
 A86	Dutch Defense: Fianchetto Variation	1. d4 f5 2. c4 Nf6 3. g3	d2d4 f7f5 c2c4 g8f6 g2g3	rnbqkb1r/ppppp1pp/5n2/5p2/2PP4/6P1/PP2PP1P/RNBQKBNR b KQkq -
 A86	Dutch Defense: Hort-Antoshin System	1. c4 f5 2. g3 Nf6 3. Bg2 d6 4. Nc3 c6 5. d4 Qc7	c2c4 f7f5 g2g3 g8f6 f1g2 d7d6 b1c3 c7c6 d2d4 d8c7	rnb1kb1r/ppq1p1pp/2pp1n2/5p2/2PP4/2N3P1/PP2PPBP/R1BQK1NR w KQkq -

--- a/dist/a.tsv
+++ b/dist/a.tsv
@@ -307,7 +307,6 @@ A13	English Opening: Agincourt Defense, Wimpy System	1. Nf3 Nf6 2. c4 e6 3. b3 d
 A13	English Opening: Neo-Catalan	1. Nf3 Nf6 2. c4 e6 3. g3 d5	g1f3 g8f6 c2c4 e7e6 g2g3 d7d5	rnbqkb1r/ppp2ppp/4pn2/3p4/2P5/5NP1/PP1PPP1P/RNBQKB1R w KQkq -
 A13	English Opening: Neo-Catalan Declined	1. Nf3 Nf6 2. c4 e6 3. g3 d5 4. Bg2 Be7	g1f3 g8f6 c2c4 e7e6 g2g3 d7d5 f1g2 f8e7	rnbqk2r/ppp1bppp/4pn2/3p4/2P5/5NP1/PP1PPPBP/RNBQK2R w KQkq -
 A13	English Opening: Romanishin Gambit	1. Nf3 Nf6 2. c4 e6 3. g3 a6 4. Bg2 b5	g1f3 g8f6 c2c4 e7e6 g2g3 a7a6 f1g2 b7b5	rnbqkb1r/2pp1ppp/p3pn2/1p6/2P5/5NP1/PP1PPPBP/RNBQK2R w KQkq -
-A13	Horwitz Defense: Zilbermints Gambit	1. d4 e6 2. e4 e5	d2d4 e7e6 e2e4 e6e5	rnbqkbnr/pppp1ppp/8/4p3/3PP3/8/PPP2PPP/RNBQKBNR w KQkq -
 A14	English Opening: Agincourt Defense, Keres Defense	1. c4 c5 2. Nf3 Nf6 3. Nc3 e6 4. g3 d5 5. cxd5 Nxd5 6. Bg2 Nc6 7. O-O Be7	c2c4 c7c5 g1f3 g8f6 b1c3 e7e6 g2g3 d7d5 c4d5 f6d5 f1g2 b8c6 e1g1 f8e7	r1bqk2r/pp2bppp/2n1p3/2pn4/8/2N2NP1/PP1PPPBP/R1BQ1RK1 w kq -
 A14	English Opening: Agincourt Defense, Neo-Catalan Declined	1. Nf3 Nf6 2. c4 e6 3. g3 d5 4. Bg2 Be7 5. O-O	g1f3 g8f6 c2c4 e7e6 g2g3 d7d5 f1g2 f8e7 e1g1	rnbqk2r/ppp1bppp/4pn2/3p4/2P5/5NP1/PP1PPPBP/RNBQ1RK1 b kq -
 A14	Réti Opening: Anglo-Slav Variation, Bogoljubov Variation, Stonewall Line	1. Nf3 d5 2. c4 e6 3. g3 Nf6 4. Bg2 Be7 5. O-O O-O 6. b3 c6 7. Bb2	g1f3 d7d5 c2c4 e7e6 g2g3 g8f6 f1g2 f8e7 e1g1 e8g8 b2b3 c7c6 c1b2	rnbq1rk1/pp2bppp/2p1pn2/3p4/2P5/1P3NP1/PB1PPPBP/RN1Q1RK1 b - -
@@ -439,6 +438,7 @@ A40	Englund Gambit Declined: Reversed Brooklyn	1. d4 e5 2. Nf3 e4 3. Ng1	d2d4 e7
 A40	Englund Gambit Declined: Reversed Krebs	1. d4 e5 2. Nf3 e4	d2d4 e7e5 g1f3 e5e4	rnbqkbnr/pppp1ppp/8/8/3Pp3/5N2/PPP1PPPP/RNBQKB1R w KQkq -
 A40	Englund Gambit Declined: Reversed Mokele Mbembe	1. d4 e5 2. Nf3 e4 3. Ne5	d2d4 e7e5 g1f3 e5e4 f3e5	rnbqkbnr/pppp1ppp/8/4N3/3Pp3/8/PPP1PPPP/RNBQKB1R b KQkq -
 A40	Horwitz Defense	1. d4 e6	d2d4 e7e6	rnbqkbnr/pppp1ppp/4p3/8/3P4/8/PPP1PPPP/RNBQKBNR w KQkq -
+A40	Horwitz Defense: Zilbermints Gambit	1. d4 e6 2. c4 e5	d2d4 e7e6 c2c4 e6e5	rnbqkbnr/pppp1ppp/8/4p3/2PP4/8/PP2PPPP/RNBQKBNR w KQkq -
 A40	Kangaroo Defense	1. d4 e6 2. c4 Bb4+	d2d4 e7e6 c2c4 f8b4	rnbqk1nr/pppp1ppp/4p3/8/1bPP4/8/PP2PPPP/RNBQKBNR w KQkq -
 A40	Kangaroo Defense: Keres Defense, Transpositional Variation	1. d4 e6 2. c4 Bb4+ 3. Nc3	d2d4 e7e6 c2c4 f8b4 b1c3	rnbqk1nr/pppp1ppp/4p3/8/1bPP4/2N5/PP2PPPP/R1BQKBNR b KQkq -
 A40	Mikenas Defense	1. d4 Nc6	d2d4 b8c6	r1bqkbnr/pppppppp/2n5/8/3P4/8/PPP1PPPP/RNBQKBNR w KQkq -

--- a/dist/b.tsv
+++ b/dist/b.tsv
@@ -231,7 +231,6 @@ B07	Lion Defense: Anti-Philidor, Lion's Cave, Lion Claw Gambit	1. e4 d6 2. d4 Nf
 B07	Lion Defense: Bayonet Attack	1. e4 d6 2. d4 Nf6 3. Nc3 Nbd7 4. g4	e2e4 d7d6 d2d4 g8f6 b1c3 b8d7 g2g4	r1bqkb1r/pppnpppp/3p1n2/8/3PP1P1/2N5/PPP2P1P/R1BQKBNR b KQkq -
 B07	Modern Defense: Geller's System	1. e4 g6 2. d4 Bg7 3. Nf3 d6 4. c3	e2e4 g7g6 d2d4 f8g7 g1f3 d7d6 c2c3	rnbqk1nr/ppp1ppbp/3p2p1/8/3PP3/2P2N2/PP3PPP/RNBQKB1R b KQkq -
 B07	Philidor Defense: Lion Variation, Lion's Claw	1. e4 d6 2. d4 Nf6 3. Nc3 c6 4. Be2 Nbd7 5. Nf3 e5 6. O-O Be7	e2e4 d7d6 d2d4 g8f6 b1c3 c7c6 f1e2 b8d7 g1f3 e7e5 e1g1 f8e7	r1bqk2r/pp1nbppp/2pp1n2/4p3/3PP3/2N2N2/PPP1BPPP/R1BQ1RK1 w kq -
-B07	Pirc Defense	1. e4 d6 2. d4 Nf6 3. Nc3	e2e4 d7d6 d2d4 g8f6 b1c3	rnbqkb1r/ppp1pppp/3p1n2/8/3PP3/2N5/PPP2PPP/R1BQKBNR b KQkq -
 B07	Pirc Defense	1. e4 d6 2. d4 Nf6 3. Nc3 g6	e2e4 d7d6 d2d4 g8f6 b1c3 g7g6	rnbqkb1r/ppp1pp1p/3p1np1/8/3PP3/2N5/PPP2PPP/R1BQKBNR w KQkq -
 B07	Pirc Defense: 150 Attack	1. e4 d6 2. d4 Nf6 3. Nc3 g6 4. Be3 c6 5. Qd2	e2e4 d7d6 d2d4 g8f6 b1c3 g7g6 c1e3 c7c6 d1d2	rnbqkb1r/pp2pp1p/2pp1np1/8/3PP3/2N1B3/PPPQ1PPP/R3KBNR b KQkq -
 B07	Pirc Defense: 150 Attack, Inner Doll Defense	1. e4 d6 2. d4 Nf6 3. Nc3 g6 4. Be3 c6 5. Qd2 Bg4	e2e4 d7d6 d2d4 g8f6 b1c3 g7g6 c1e3 c7c6 d1d2 c8g4	rn1qkb1r/pp2pp1p/2pp1np1/8/3PP1b1/2N1B3/PPPQ1PPP/R3KBNR w KQkq -

--- a/dist/c.tsv
+++ b/dist/c.tsv
@@ -352,8 +352,8 @@ C30	King's Gambit Declined: Petrov's Defense	1. e4 e5 2. f4 Nf6	e2e4 e7e5 f2f4 g
 C30	King's Gambit Declined: Queen's Knight Defense	1. e4 e5 2. f4 Nc6	e2e4 e7e5 f2f4 b8c6	r1bqkbnr/pppp1ppp/2n5/4p3/4PP2/8/PPPP2PP/RNBQKBNR w KQkq -
 C30	King's Gambit Declined: Senechaud Countergambit	1. e4 e5 2. f4 Bc5 3. Nf3 g5	e2e4 e7e5 f2f4 f8c5 g1f3 g7g5	rnbqk1nr/pppp1p1p/8/2b1p1p1/4PP2/5N2/PPPP2PP/RNBQKB1R w KQkq -
 C30	King's Gambit Declined: Soller-Zilbermints Gambit	1. e4 e5 2. f4 f6 3. fxe5 Nc6	e2e4 e7e5 f2f4 f7f6 f4e5 b8c6	r1bqkbnr/pppp2pp/2n2p2/4P3/4P3/8/PPPP2PP/RNBQKBNR w KQkq -
+C30	King's Gambit Declined: Zilbermints Double Countergambit	1. e4 e5 2. f4 g5	e2e4 e7e5 f2f4 g7g5	rnbqkbnr/pppp1p1p/8/4p1p1/4PP2/8/PPPP2PP/RNBQKBNR w KQkq -
 C30	King's Gambit Declined: Zilbermints Double Gambit	1. e4 e5 2. f4 Nc6 3. Nf3 g5	e2e4 e7e5 f2f4 b8c6 g1f3 g7g5	r1bqkbnr/pppp1p1p/2n5/4p1p1/4PP2/5N2/PPPP2PP/RNBQKB1R w KQkq -
-C30	King's Gambit: Zilbermints Double Countergambit	1. e4 e5 2. f4 g5	e2e4 e7e5 f2f4 g7g5	rnbqkbnr/pppp1p1p/8/4p1p1/4PP2/8/PPPP2PP/RNBQKBNR w KQkq -
 C31	King's Gambit Declined: Falkbeer Countergambit	1. e4 e5 2. f4 d5	e2e4 e7e5 f2f4 d7d5	rnbqkbnr/ppp2ppp/8/3pp3/4PP2/8/PPPP2PP/RNBQKBNR w KQkq -
 C31	King's Gambit Declined: Falkbeer Countergambit Accepted	1. e4 e5 2. f4 d5 3. exd5	e2e4 e7e5 f2f4 d7d5 e4d5	rnbqkbnr/ppp2ppp/8/3Pp3/5P2/8/PPPP2PP/RNBQKBNR b KQkq -
 C31	King's Gambit Declined: Falkbeer Countergambit, Anderssen Attack	1. e4 e5 2. f4 d5 3. exd5 e4 4. Bb5+	e2e4 e7e5 f2f4 d7d5 e4d5 e5e4 f1b5	rnbqkbnr/ppp2ppp/8/1B1P4/4pP2/8/PPPP2PP/RNBQK1NR b KQkq -

--- a/dist/d.tsv
+++ b/dist/d.tsv
@@ -1,6 +1,6 @@
 eco	name	pgn	uci	epd
 D00	Amazon Attack	1. d4 d5 2. Qd3	d2d4 d7d5 d1d3	rnbqkbnr/ppp1pppp/8/3p4/3P4/3Q4/PPP1PPPP/RNB1KBNR b KQkq -
-D00	Blackmar Gambit	1. d4 d5 2. e4	d2d4 d7d5 e2e4	rnbqkbnr/ppp1pppp/8/3p4/3PP3/8/PPP2PPP/RNBQKBNR b KQkq -
+D00	Blackmar-Diemer Gambit	1. d4 d5 2. e4	d2d4 d7d5 e2e4	rnbqkbnr/ppp1pppp/8/3p4/3PP3/8/PPP2PPP/RNBQKBNR b KQkq -
 D00	Blackmar-Diemer Gambit	1. d4 d5 2. e4 dxe4 3. Nc3	d2d4 d7d5 e2e4 d5e4 b1c3	rnbqkbnr/ppp1pppp/8/8/3Pp3/2N5/PPP2PPP/R1BQKBNR b KQkq -
 D00	Blackmar-Diemer Gambit	1. d4 Nf6 2. Nc3 d5 3. e4	d2d4 g8f6 b1c3 d7d5 e2e4	rnbqkb1r/ppp1pppp/5n2/3p4/3PP3/2N5/PPP2PPP/R1BQKBNR b KQkq -
 D00	Blackmar-Diemer Gambit Declined: Brombacher Countergambit	1. d4 Nf6 2. Nc3 d5 3. e4 dxe4 4. f3 c5	d2d4 g8f6 b1c3 d7d5 e2e4 d5e4 f2f3 c7c5	rnbqkb1r/pp2pppp/5n2/2p5/3Pp3/2N2P2/PPP3PP/R1BQKBNR w KQkq -
@@ -19,6 +19,7 @@ D00	Blackmar-Diemer Gambit: Euwe Defense, Zilbermints Gambit	1. d4 d5 2. e4 dxe4
 D00	Blackmar-Diemer Gambit: Fritz Attack	1. d4 d5 2. e4 dxe4 3. Bc4	d2d4 d7d5 e2e4 d5e4 f1c4	rnbqkbnr/ppp1pppp/8/8/2BPp3/8/PPP2PPP/RNBQK1NR b KQkq -
 D00	Blackmar-Diemer Gambit: Gedult Gambit	1. d4 d5 2. e4 dxe4 3. f3	d2d4 d7d5 e2e4 d5e4 f2f3	rnbqkbnr/ppp1pppp/8/8/3Pp3/5P2/PPP3PP/RNBQKBNR b KQkq -
 D00	Blackmar-Diemer Gambit: Kaulich Defense	1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. f3 exf3 5. Nxf3 c5	d2d4 d7d5 e2e4 d5e4 b1c3 g8f6 f2f3 e4f3 g1f3 c7c5	rnbqkb1r/pp2pppp/5n2/2p5/3P4/2N2N2/PPP3PP/R1BQKB1R w KQkq -
+D00	Blackmar-Diemer Gambit: Lemberger Countergambit	1. d4 d5 2. Nc3 Nf6 3. e4 e5	d2d4 d7d5 b1c3 g8f6 e2e4 e7e5	rnbqkb1r/ppp2ppp/5n2/3pp3/3PP3/2N5/PPP2PPP/R1BQKBNR w KQkq -
 D00	Blackmar-Diemer Gambit: Lemberger Countergambit, Diemer Attack	1. d4 d5 2. e4 dxe4 3. Nc3 e5 4. Be3	d2d4 d7d5 e2e4 d5e4 b1c3 e7e5 c1e3	rnbqkbnr/ppp2ppp/8/4p3/3Pp3/2N1B3/PPP2PPP/R2QKBNR b KQkq -
 D00	Blackmar-Diemer Gambit: Lemberger Countergambit, Endgame Variation	1. d4 d5 2. e4 dxe4 3. Nc3 e5 4. dxe5	d2d4 d7d5 e2e4 d5e4 b1c3 e7e5 d4e5	rnbqkbnr/ppp2ppp/8/4P3/4p3/2N5/PPP2PPP/R1BQKBNR b KQkq -
 D00	Blackmar-Diemer Gambit: Lemberger Countergambit, Rassmussen Attack	1. d4 d5 2. e4 dxe4 3. Nc3 e5 4. Nge2	d2d4 d7d5 e2e4 d5e4 b1c3 e7e5 g1e2	rnbqkbnr/ppp2ppp/8/4p3/3Pp3/2N5/PPP1NPPP/R1BQKB1R b KQkq -
@@ -39,7 +40,6 @@ D00	Blackmar-Diemer Gambit: Zeller Defense, Soller Attack	1. d4 d5 2. e4 dxe4 3.
 D00	Blackmar-Diemer Gambit: Ziegler Defense	1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. f3 exf3 5. Nxf3 c6	d2d4 d7d5 e2e4 d5e4 b1c3 g8f6 f2f3 e4f3 g1f3 c7c6	rnbqkb1r/pp2pppp/2p2n2/8/3P4/2N2N2/PPP3PP/R1BQKB1R w KQkq -
 D00	Blackmar-Diemer Gambit: von Popiel Gambit	1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. Bg5	d2d4 d7d5 e2e4 d5e4 b1c3 g8f6 c1g5	rnbqkb1r/ppp1pppp/5n2/6B1/3Pp3/2N5/PPP2PPP/R2QKBNR b KQkq -
 D00	Blackmar-Diemer Gambit: von Popiel Gambit, Zilbermints Variation	1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. Bg5 Bf5 5. Bxf6 exf6 6. g4 Bg6 7. Qe2 Bb4 8. Qb5+	d2d4 d7d5 e2e4 d5e4 b1c3 g8f6 c1g5 c8f5 g5f6 e7f6 g2g4 f5g6 d1e2 f8b4 e2b5	rn1qk2r/ppp2ppp/5pb1/1Q6/1b1Pp1P1/2N5/PPP2P1P/R3KBNR b KQkq -
-D00	Blackmar-Diemer, Lemberger Countergambit	1. d4 d5 2. Nc3 Nf6 3. e4 e5	d2d4 d7d5 b1c3 g8f6 e2e4 e7e5	rnbqkb1r/ppp2ppp/5n2/3pp3/3PP3/2N5/PPP2PPP/R1BQKBNR w KQkq -
 D00	Queen's Pawn Game	1. d4 d5	d2d4 d7d5	rnbqkbnr/ppp1pppp/8/3p4/3P4/8/PPP1PPPP/RNBQKBNR w KQkq -
 D00	Queen's Pawn Game	1. d4 d5 2. e3	d2d4 d7d5 e2e3	rnbqkbnr/ppp1pppp/8/3p4/3P4/4P3/PPP2PPP/RNBQKBNR b KQkq -
 D00	Queen's Pawn Game	1. d4 d5 2. e3 Nf6	d2d4 d7d5 e2e3 g8f6	rnbqkb1r/ppp1pppp/5n2/3p4/3P4/4P3/PPP2PPP/RNBQKBNR w KQkq -
@@ -287,10 +287,10 @@ D34	Tarrasch Defense: Classical Variation, Réti Variation	1. d4 d5 2. c4 e6 3. 
 D34	Tarrasch Defense: Classical Variation, Spassky Variation	1. d4 d5 2. c4 e6 3. Nc3 c5 4. cxd5 exd5 5. Nf3 Nc6 6. g3 Nf6 7. Bg2 Be7 8. O-O O-O 9. Bg5 cxd4 10. Nxd4 h6 11. Be3 Bg4	d2d4 d7d5 c2c4 e7e6 b1c3 c7c5 c4d5 e6d5 g1f3 b8c6 g2g3 g8f6 f1g2 f8e7 e1g1 e8g8 c1g5 c5d4 f3d4 h7h6 g5e3 c8g4	r2q1rk1/pp2bpp1/2n2n1p/3p4/3N2b1/2N1B1P1/PP2PPBP/R2Q1RK1 w - -
 D34	Tarrasch Defense: Prague Variation, Main Line	1. d4 d5 2. c4 e6 3. Nc3 c5 4. cxd5 exd5 5. Nf3 Nc6 6. g3 Nf6 7. Bg2 Be7	d2d4 d7d5 c2c4 e7e6 b1c3 c7c5 c4d5 e6d5 g1f3 b8c6 g2g3 g8f6 f1g2 f8e7	r1bqk2r/pp2bppp/2n2n2/2pp4/3P4/2N2NP1/PP2PPBP/R1BQK2R w KQkq -
 D35	Queen's Gambit Declined: Exchange Variation	1. d4 Nf6 2. c4 e6 3. Nc3 d5 4. cxd5	d2d4 g8f6 c2c4 e7e6 b1c3 d7d5 c4d5	rnbqkb1r/ppp2ppp/4pn2/3P4/3P4/2N5/PP2PPPP/R1BQKBNR b KQkq -
+D35	Queen's Gambit Declined: Exchange Variation, Chameleon Variation	1. d4 Nf6 2. c4 e6 3. Nc3 d5 4. cxd5 exd5 5. Bg5 Be7 6. e3 O-O 7. Bd3 Nbd7 8. Qc2 Re8 9. Nge2 Nf8 10. O-O-O	d2d4 g8f6 c2c4 e7e6 b1c3 d7d5 c4d5 e6d5 c1g5 f8e7 e2e3 e8g8 f1d3 b8d7 d1c2 f8e8 g1e2 d7f8 e1c1	r1bqrnk1/ppp1bppp/5n2/3p2B1/3P4/2NBP3/PPQ1NPPP/2KR3R b - -
 D35	Queen's Gambit Declined: Exchange Variation, Positional Variation	1. d4 Nf6 2. c4 e6 3. Nc3 d5 4. cxd5 exd5 5. Bg5	d2d4 g8f6 c2c4 e7e6 b1c3 d7d5 c4d5 e6d5 c1g5	rnbqkb1r/ppp2ppp/5n2/3p2B1/3P4/2N5/PP2PPPP/R2QKBNR b KQkq -
 D35	Queen's Gambit Declined: Exchange Variation, Positional Variation	1. d4 Nf6 2. c4 e6 3. Nc3 d5 4. cxd5 exd5 5. Bg5 c6	d2d4 g8f6 c2c4 e7e6 b1c3 d7d5 c4d5 e6d5 c1g5 c7c6	rnbqkb1r/pp3ppp/2p2n2/3p2B1/3P4/2N5/PP2PPPP/R2QKBNR w KQkq -
 D35	Queen's Gambit Declined: Exchange Variation, Sämisch Variation	1. d4 Nf6 2. c4 e6 3. Nf3 d5 4. Nc3 Nbd7 5. cxd5 exd5 6. Bf4	d2d4 g8f6 c2c4 e7e6 g1f3 d7d5 b1c3 b8d7 c4d5 e6d5 c1f4	r1bqkb1r/pppn1ppp/5n2/3p4/3P1B2/2N2N2/PP2PPPP/R2QKB1R b KQkq -
-D35	Queen's Gambit Declined: Exchange, Chameleon Variation	1. d4 Nf6 2. c4 e6 3. Nc3 d5 4. cxd5 exd5 5. Bg5 Be7 6. e3 O-O 7. Bd3 Nbd7 8. Qc2 Re8 9. Nge2 Nf8 10. O-O-O	d2d4 g8f6 c2c4 e7e6 b1c3 d7d5 c4d5 e6d5 c1g5 f8e7 e2e3 e8g8 f1d3 b8d7 d1c2 f8e8 g1e2 d7f8 e1c1	r1bqrnk1/ppp1bppp/5n2/3p2B1/3P4/2NBP3/PPQ1NPPP/2KR3R b - -
 D35	Queen's Gambit Declined: Harrwitz Attack	1. d4 d5 2. c4 e6 3. Nc3 Nf6 4. Bf4	d2d4 d7d5 c2c4 e7e6 b1c3 g8f6 c1f4	rnbqkb1r/ppp2ppp/4pn2/3p4/2PP1B2/2N5/PP2PPPP/R2QKBNR b KQkq -
 D35	Queen's Gambit Declined: Normal Defense	1. d4 d5 2. c4 e6 3. Nc3 Nf6	d2d4 d7d5 c2c4 e7e6 b1c3 g8f6	rnbqkb1r/ppp2ppp/4pn2/3p4/2PP4/2N5/PP2PPPP/R1BQKBNR w KQkq -
 D36	Queen's Gambit Declined: Exchange Variation, Reshevsky Variation	1. d4 Nf6 2. c4 e6 3. Nc3 d5 4. cxd5 exd5 5. Bg5 c6 6. Qc2	d2d4 g8f6 c2c4 e7e6 b1c3 d7d5 c4d5 e6d5 c1g5 c7c6 d1c2	rnbqkb1r/pp3ppp/2p2n2/3p2B1/3P4/2N5/PPQ1PPPP/R3KBNR b KQkq -


### PR DESCRIPTION
See [comment](https://github.com/lichess-org/chess-openings/issues/46#issuecomment-1166375218). 

Also fixed some other small stuff I saw on the way:
- Queens Gambit: Exchange -> Queens Gambit: Exchange Variation
- King's Gambit: Zilbermints Double Countergambit -> King's Gambit Declined: Zilbermints Double Countergambit
- Switched move order for Horwitz Defense: Zilbermints Gambit to be consistent with base Horwitz Defense
- Horwitz Defense: Dutch Defense, Bellon Gambit -> Dutch Defense: Bellon Gambit (and switch move order to be Dutch)
- Blackmar-Diemer, Lemberger Countergambit -> Blackmar-Diemer Gambit: Lemberger Countergambit
