### PR TITLE
Morphy Gambit: e4 before d4

### DIFF
--- a/b.tsv
+++ b/b.tsv
@@ -382,8 +382,8 @@ B21	Sicilian Defense: Coles Sicilian Gambit	1. e4 c5 2. d4 cxd4 3. Qxd4 Nc6 4. Q
 B21	Sicilian Defense: Halasz Gambit	1. e4 c5 2. d4 cxd4 3. f4
 B21	Sicilian Defense: McDonnell Attack	1. e4 c5 2. f4
 B21	Sicilian Defense: McDonnell Attack, Tal Gambit	1. e4 c5 2. f4 d5 3. exd5 Nf6
-B21	Sicilian Defense: Morphy Gambit	1. d4 c5 2. e4 cxd4 3. Nf3
-B21	Sicilian Defense: Morphy Gambit, Andreaschek Gambit	1. d4 c5 2. e4 cxd4 3. Nf3 e5 4. c3
+B21	Sicilian Defense: Morphy Gambit	1. e4 c5 2. d4 cxd4 3. Nf3
+B21	Sicilian Defense: Morphy Gambit, Andreaschek Gambit	1. e4 c5 2. d4 cxd4 3. Nf3 e5 4. c3
 B21	Sicilian Defense: Smith-Morra Gambit	1. e4 c5 2. d4
 B21	Sicilian Defense: Smith-Morra Gambit	1. e4 c5 2. d4 cxd4 3. c3
 B21	Sicilian Defense: Smith-Morra Gambit Accepted, Chicago Defense	1. e4 c5 2. d4 cxd4 3. c3 dxc3 4. Nxc3 d6 5. Nf3 e6 6. Bc4 Nf6 7. O-O a6

--- a/dist/b.tsv
+++ b/dist/b.tsv
@@ -382,8 +382,8 @@ B21	Sicilian Defense: Coles Sicilian Gambit	1. e4 c5 2. d4 cxd4 3. Qxd4 Nc6 4. Q
 B21	Sicilian Defense: Halasz Gambit	1. e4 c5 2. d4 cxd4 3. f4	e2e4 c7c5 d2d4 c5d4 f2f4	rnbqkbnr/pp1ppppp/8/8/3pPP2/8/PPP3PP/RNBQKBNR b KQkq -
 B21	Sicilian Defense: McDonnell Attack	1. e4 c5 2. f4	e2e4 c7c5 f2f4	rnbqkbnr/pp1ppppp/8/2p5/4PP2/8/PPPP2PP/RNBQKBNR b KQkq -
 B21	Sicilian Defense: McDonnell Attack, Tal Gambit	1. e4 c5 2. f4 d5 3. exd5 Nf6	e2e4 c7c5 f2f4 d7d5 e4d5 g8f6	rnbqkb1r/pp2pppp/5n2/2pP4/5P2/8/PPPP2PP/RNBQKBNR w KQkq -
-B21	Sicilian Defense: Morphy Gambit	1. d4 c5 2. e4 cxd4 3. Nf3	d2d4 c7c5 e2e4 c5d4 g1f3	rnbqkbnr/pp1ppppp/8/8/3pP3/5N2/PPP2PPP/RNBQKB1R b KQkq -
-B21	Sicilian Defense: Morphy Gambit, Andreaschek Gambit	1. d4 c5 2. e4 cxd4 3. Nf3 e5 4. c3	d2d4 c7c5 e2e4 c5d4 g1f3 e7e5 c2c3	rnbqkbnr/pp1p1ppp/8/4p3/3pP3/2P2N2/PP3PPP/RNBQKB1R b KQkq -
+B21	Sicilian Defense: Morphy Gambit	1. e4 c5 2. d4 cxd4 3. Nf3	e2e4 c7c5 d2d4 c5d4 g1f3	rnbqkbnr/pp1ppppp/8/8/3pP3/5N2/PPP2PPP/RNBQKB1R b KQkq -
+B21	Sicilian Defense: Morphy Gambit, Andreaschek Gambit	1. e4 c5 2. d4 cxd4 3. Nf3 e5 4. c3	e2e4 c7c5 d2d4 c5d4 g1f3 e7e5 c2c3	rnbqkbnr/pp1p1ppp/8/4p3/3pP3/2P2N2/PP3PPP/RNBQKB1R b KQkq -
 B21	Sicilian Defense: Smith-Morra Gambit	1. e4 c5 2. d4	e2e4 c7c5 d2d4	rnbqkbnr/pp1ppppp/8/2p5/3PP3/8/PPP2PPP/RNBQKBNR b KQkq -
 B21	Sicilian Defense: Smith-Morra Gambit	1. e4 c5 2. d4 cxd4 3. c3	e2e4 c7c5 d2d4 c5d4 c2c3	rnbqkbnr/pp1ppppp/8/8/3pP3/2P5/PP3PPP/RNBQKBNR b KQkq -
 B21	Sicilian Defense: Smith-Morra Gambit Accepted, Chicago Defense	1. e4 c5 2. d4 cxd4 3. c3 dxc3 4. Nxc3 d6 5. Nf3 e6 6. Bc4 Nf6 7. O-O a6	e2e4 c7c5 d2d4 c5d4 c2c3 d4c3 b1c3 d7d6 g1f3 e7e6 f1c4 g8f6 e1g1 a7a6	rnbqkb1r/1p3ppp/p2ppn2/8/2B1P3/2N2N2/PP3PPP/R1BQ1RK1 w kq -


### PR DESCRIPTION
That way it actually aligns with the "Sicilian" in its name and this seems to be the generally considered move order:
- https://www.chess.com/openings/Sicilian-Defense-Smith-Morra-Morphy-Gambit
- https://old.chesstempo.com/gamedb/opening/2143
- also seems to be more common in master games if I'm reading the explorer correctly