### PR TITLE
Make Maroczy Defense actually a King's Pawn Game

### DIFF
--- a/b.tsv
+++ b/b.tsv
@@ -222,7 +222,7 @@ B06	Pterodactyl Defense: Western, Anhanguera	1. e4 g6 2. d4 Bg7 3. Nf3 c5 4. Be3
 B06	Pterodactyl Defense: Western, Siroccopteryx	1. e4 g6 2. Nf3 Bg7 3. d4 c5 4. Bc4 cxd4 5. Nxd4 Qa5+
 B06	Rat Defense: Accelerated Gurgenidze	1. e4 g6 2. d4 d6 3. Nc3 c6
 B07	Czech Defense	1. e4 d6 2. d4 Nf6 3. Nc3 c6
-B07	King's Pawn Game: Maróczy Defense	1. d4 d6 2. e4 e5
+B07	King's Pawn Game: Maróczy Defense	1. e4 d6 2. d4 e5
 B07	Lion Defense: Anti-Philidor	1. e4 d6 2. d4 Nf6 3. Nc3 Nbd7 4. f4
 B07	Lion Defense: Anti-Philidor, Lion's Cave	1. e4 d6 2. d4 Nf6 3. Nc3 Nbd7 4. f4 e5
 B07	Lion Defense: Anti-Philidor, Lion's Cave, Lion Claw Gambit	1. e4 d6 2. d4 Nf6 3. Nc3 Nbd7 4. f4 e5 5. Nf3 exd4 6. Qxd4 c6 7. Bc4 d5

--- a/dist/b.tsv
+++ b/dist/b.tsv
@@ -222,7 +222,7 @@ B06	Pterodactyl Defense: Western, Anhanguera	1. e4 g6 2. d4 Bg7 3. Nf3 c5 4. Be3
 B06	Pterodactyl Defense: Western, Siroccopteryx	1. e4 g6 2. Nf3 Bg7 3. d4 c5 4. Bc4 cxd4 5. Nxd4 Qa5+	e2e4 g7g6 g1f3 f8g7 d2d4 c7c5 f1c4 c5d4 f3d4 d8a5	rnb1k1nr/pp1pppbp/6p1/q7/2BNP3/8/PPP2PPP/RNBQK2R w KQkq -
 B06	Rat Defense: Accelerated Gurgenidze	1. e4 g6 2. d4 d6 3. Nc3 c6	e2e4 g7g6 d2d4 d7d6 b1c3 c7c6	rnbqkbnr/pp2pp1p/2pp2p1/8/3PP3/2N5/PPP2PPP/R1BQKBNR w KQkq -
 B07	Czech Defense	1. e4 d6 2. d4 Nf6 3. Nc3 c6	e2e4 d7d6 d2d4 g8f6 b1c3 c7c6	rnbqkb1r/pp2pppp/2pp1n2/8/3PP3/2N5/PPP2PPP/R1BQKBNR w KQkq -
-B07	King's Pawn Game: Maróczy Defense	1. d4 d6 2. e4 e5	d2d4 d7d6 e2e4 e7e5	rnbqkbnr/ppp2ppp/3p4/4p3/3PP3/8/PPP2PPP/RNBQKBNR w KQkq -
+B07	King's Pawn Game: Maróczy Defense	1. e4 d6 2. d4 e5	e2e4 d7d6 d2d4 e7e5	rnbqkbnr/ppp2ppp/3p4/4p3/3PP3/8/PPP2PPP/RNBQKBNR w KQkq -
 B07	Lion Defense: Anti-Philidor	1. e4 d6 2. d4 Nf6 3. Nc3 Nbd7 4. f4	e2e4 d7d6 d2d4 g8f6 b1c3 b8d7 f2f4	r1bqkb1r/pppnpppp/3p1n2/8/3PPP2/2N5/PPP3PP/R1BQKBNR b KQkq -
 B07	Lion Defense: Anti-Philidor, Lion's Cave	1. e4 d6 2. d4 Nf6 3. Nc3 Nbd7 4. f4 e5	e2e4 d7d6 d2d4 g8f6 b1c3 b8d7 f2f4 e7e5	r1bqkb1r/pppn1ppp/3p1n2/4p3/3PPP2/2N5/PPP3PP/R1BQKBNR w KQkq -
 B07	Lion Defense: Anti-Philidor, Lion's Cave, Lion Claw Gambit	1. e4 d6 2. d4 Nf6 3. Nc3 Nbd7 4. f4 e5 5. Nf3 exd4 6. Qxd4 c6 7. Bc4 d5	e2e4 d7d6 d2d4 g8f6 b1c3 b8d7 f2f4 e7e5 g1f3 e5d4 d1d4 c7c6 f1c4 d6d5	r1bqkb1r/pp1n1ppp/2p2n2/3p4/2BQPP2/2N2N2/PPP3PP/R1B1K2R w KQkq -


### PR DESCRIPTION
Also seems to be the common move order: https://www.chess.com/openings/Pirc-Defense-Maroczy-Defense

Though actually it maybe should even be considered a Pirc? CC also has it like that.