### PR TITLE
Scandinavian Defense: Portuguese Gambit

### DIFF
--- a/b.tsv
+++ b/b.tsv
@@ -109,8 +109,15 @@ B01	Scandinavian Defense: Modern Variation	1. e4 d5 2. exd5 Nf6 3. d4
 B01	Scandinavian Defense: Modern Variation, Gipslis Variation	1. e4 d5 2. exd5 Nf6 3. d4 Nxd5 4. Nf3 Bg4
 B01	Scandinavian Defense: Modern Variation, Wing Gambit	1. e4 d5 2. exd5 Nf6 3. d4 g6 4. c4 b5
 B01	Scandinavian Defense: Panov Transfer	1. e4 d5 2. exd5 Nf6 3. c4 c6
-B01	Scandinavian Defense: Portuguese Variation	1. e4 d5 2. exd5 Nf6 3. d4 Bg4
-B01	Scandinavian Defense: Portuguese Variation, Portuguese Gambit	1. e4 d5 2. exd5 Nf6 3. d4 Bg4 4. Bb5+ Nbd7 5. f3 Bf5
+B01	Scandinavian Defense: Portuguese Gambit	1. e4 d5 2. exd5 Nf6 3. d4 Bg4
+B01	Scandinavian Defense: Portuguese Gambit, Banker Variation	1. e4 d5 2. exd5 Nf6 3. d4 Bg4 4. f3 Bf5 5. c4
+B01	Scandinavian Defense: Portuguese Gambit, Classical Variation	1. e4 d5 2. exd5 Nf6 3. d4 Bg4 4. Nf3
+B01	Scandinavian Defense: Portuguese Gambit, Correspondence Refutation	1. e4 d5 2. exd5 Nf6 3. d4 Bg4 4. f3 Bf5 5. g4
+B01	Scandinavian Defense: Portuguese Gambit, Elbow Variation	1. e4 d5 2. exd5 Nf6 3. d4 Bg4 4. Bb5+ c6
+B01	Scandinavian Defense: Portuguese Gambit, Jadoul Variation	1. e4 d5 2. exd5 Nf6 3. d4 Bg4 4. f3 Bf5 5. Bb5+ Nbd7 6. c4
+B01	Scandinavian Defense: Portuguese Gambit, Lusophobe Variation	1. e4 d5 2. exd5 Nf6 3. d4 Bg4 4. Bb5+ Nbd7 5. Be2
+B01	Scandinavian Defense: Portuguese Gambit, Melbourne Shuffle Variation	1. e4 d5 2. exd5 Nf6 3. d4 Bg4 4. f3 Bf5 5. Bb5+ Nbd7 6. Nc3
+B01	Scandinavian Defense: Portuguese Gambit, Wuss Variation	1. e4 d5 2. exd5 Nf6 3. d4 Bg4 4. Be2
 B01	Scandinavian Defense: Richter Variation	1. e4 d5 2. exd5 Nf6 3. d4 Nxd5 4. Nf3 g6
 B01	Scandinavian Defense: Richter Variation	1. e4 d5 2. exd5 Nf6 3. d4 g6
 B01	Scandinavian Defense: Schiller-Pytel Variation	1. e4 d5 2. exd5 Qxd5 3. Nc3 Qd6 4. d4 c6


### PR DESCRIPTION
# Changelog
- Removed `1. e4 d5 2. exd5 Nf6 3. d4 Bg4 4. Bb5+ Nbd7 5. f3 Bf5` named `Scandinavian Defense: Portuguese Variation, Portuguese Gambit`.
- Renamed `1. e4 d5 2. exd5 Nf6 3. d4 Bg4` from `Scandinavian Defense: Portuguese Variation` to `Scandinavian Defense: Portuguese Gambit`.
- Added `1. e4 d5 2. exd5 Nf6 3. d4 Bg4 4. f3 Bf5 5. c4` named `Scandinavian Defense: Portuguese Gambit, Banker Variation`.
- Added `1. e4 d5 2. exd5 Nf6 3. d4 Bg4 4. Nf3` named `Scandinavian Defense: Portuguese Gambit, Classical Variation`.
- Added `1. e4 d5 2. exd5 Nf6 3. d4 Bg4 4. f3 Bf5 5. g4` named `Scandinavian Defense: Portuguese Gambit, Correspondence Refutation`.
- Added `1. e4 d5 2. exd5 Nf6 3. d4 Bg4 4. Bb5+ c6` named `Scandinavian Defense: Portuguese Gambit, Elbow Variation`.
- Added `1. e4 d5 2. exd5 Nf6 3. d4 Bg4 4. f3 Bf5 5. Bb5+ Nbd7 6. c4` named `Scandinavian Defense: Portuguese Gambit, Jadoul Variation`.
- Added `1. e4 d5 2. exd5 Nf6 3. d4 Bg4 4. Bb5+ Nbd7 5. Be2` named `Scandinavian Defense: Portuguese Gambit, Lusophobe Variation`.
- Added `1. e4 d5 2. exd5 Nf6 3. d4 Bg4 4. f3 Bf5 5. Bb5+ Nbd7 6. Nc3` named `Scandinavian Defense: Portuguese Gambit, Melbourne Shuffle Variation`.
- Added `1. e4 d5 2. exd5 Nf6 3. d4 Bg4 4. Be2` named `Scandinavian Defense: Portuguese Gambit, Wuss Variation`.

# The Name of `1. e4 d5 2. exd5 Nf6 3. d4 Bg4`
This line `1. e4 d5 2. exd5 Nf6 3. d4 Bg4` in the Scandinavian Defense has many different names across chess literature. Selby Anderson released the book [Center Counter Defense: The Portuguese Variation](https://www.amazon.com/Center-Counter-Defense-Portuguese-Variation/dp/1886846103) in the year 1997 and, apparently, named it `Portuguese Variation`. In his book [Smerdon's Scandinavian](https://www.amazon.com/Smerdons-Scandinavian-David-Smerdon/dp/1781942943), [David Smerdon](https://en.wikipedia.org/wiki/David_Smerdon) called this line `Portuguese Complex`, but he noted that it was also called `Portuguese Opening` as well as `Jadoul Variation` [Section 1]. It's called `Portuguese Gambit` in Wikipedia's [list of chess gambits](https://en.wikipedia.org/wiki/List_of_chess_gambits#Scandinavian_Defense) and `Portuguese Variation` as well as `Jadoul Variation` in Wikipedia's article on the [Scandinavian Defense](https://en.wikipedia.org/wiki/Scandinavian_Defense#2...Nf6). (Unfortunately, I was unable to check the sources Wikipedia provides because I couldn't find the referenced books.)

Since Selby Anderson's book predates all other sources, there is an argument to name this line `Portuguese Variation`. However, Black delays taking back the pawn on d5 twice (first time with `2... Nf6` and second time with `3... Bg4`). This gives White the opportunity to secure the extra pawn with e.g. `1. e4 d5 2. exd5 Nf6 3. d4 Bg4 4. f3 Bf5 5. g4 Bg6 6. c4`. Additionally, Selby Anderson may not have been aware of the dubious nature of this variation ([Stockfish gives White +0.8](https://lichess.org/7CAhQOCs)). Furthermore, David Smerdon repeatedly refers to this line as a gambit despite calling it `Portuguese Complex`. Because of this, I argue that this line should be called the `Portuguese Gambit`.

# Variations in the `Portuguese Gambit`
[Smerdon's Scandinavian](https://www.amazon.com/Smerdons-Scandinavian-David-Smerdon/dp/1781942943) is currently the most extensive book on the `Portuguese Gambit`. It categorizes all major responses from White after `1. e4 d5 2. exd5 Nf6 3. d4 Bg4`. Smerdon also offers creative names for all variations covered by his theory. Here are the variations sorted by chapter:
1. `1. e4 d5 2. exd5 Nf6 3. d4 Bg4 4. f3 Bf5 5. c4` is called `The Banker`. (White "banks" the extra pawn with the immediate `5. c4`.)
2. `1. e4 d5 2. exd5 Nf6 3. d4 Bg4 4. f3 Bf5 5. Bb5+ Nbd7 6. c4` is called `The Jadoul`. (Named after [Michel Jadoul](https://de.wikipedia.org/wiki/Michel_Jadoul) who is one of the earliest exponents of the Portuguese Gambit [Introduction, Inspirational Game 1].)
3. `1. e4 d5 2. exd5 Nf6 3. d4 Bg4 4. f3 Bf5 5. Bb5+ Nbd7 6. Nc3` is called `The Melbourne Shuffle`. (Played by many australian IMs from Melbourne [Chapter 3]. It is named after a [rave dance](https://en.wikipedia.org/wiki/Melbourne_shuffle) which originated in Melbourne.)
4. `1. e4 d5 2. exd5 Nf6 3. d4 Bg4 4. f3 Bf5 5. g4` is called `The Correspondence Refutation`. (A line against the `Portuguese Gambit` successfully employed by the correspondence community [Chapter 4].)
5. `1. e4 d5 2. exd5 Nf6 3. d4 Bg4 4. Be2` is called `The Wuss`. (Apparently, `4. Be2` is a wimpy move and only a [wuss](https://www.merriam-webster.com/dictionary/wuss) would play it.)
6. `1. e4 d5 2. exd5 Nf6 3. d4 Bg4 4. Bb5+ Nbd7 5. Be2` is called `The Lusophobe`. (According to Wikipedia, [Lusophobia](https://en.wikipedia.org/wiki/Lusophobia) is irrational hostility, racism or hatred towards Portugal, the Portuguese people or the Portuguese language and culture. David Smerdon is making a joke by referring to the line `4. Bb5+ Nbd7 5. Be2` as "Anti-Portuguese" or "effective against the Portuguese Gambit".)
7. `1. e4 d5 2. exd5 Nf6 3. d4 Bg4 4. Bb5+ c6` is called `The Elbow`. (Given the effectivness of the line `4. Bb5+ Nbd7 5. Be2`, occasionally playing `4... c6` may discourage players from studying it while preparing against you. Hitting your well prepared opponent with your elbow is a metaphor for playing `4... c6` [Chapter 7].)
8. `1. e4 d5 2. exd5 Nf6 3. d4 Bg4 4. Nf3` is called `The Classical`. (Refers to the fact that the move `4. Nf3` is principled [Chapter 8].)