### PR TITLE
Blackmar-Diemer Gambit Overhaul

### DIFF
--- a/b.tsv
+++ b/b.tsv
@@ -47,6 +47,7 @@ B00	Nimzowitsch Defense: Scandinavian Variation	1. e4 Nc6 2. d4 d5
 B00	Nimzowitsch Defense: Scandinavian Variation, Aachen Gambit	1. e4 Nc6 2. d4 d5 3. exd5 Nb4
 B00	Nimzowitsch Defense: Scandinavian Variation, Advance Variation	1. e4 Nc6 2. d4 d5 3. e5
 B00	Nimzowitsch Defense: Scandinavian Variation, Bogoljubov Variation	1. e4 Nc6 2. d4 d5 3. Nc3
+B00	Nimzowitsch Defense: Scandinavian Variation, Bogoljubov Variation	1. e4 Nc6 2. d4 d5 3. Nc3 dxe4
 B00	Nimzowitsch Defense: Scandinavian Variation, Bogoljubov Variation, Brandics Gambit	1. e4 Nc6 2. d4 d5 3. Nc3 a6
 B00	Nimzowitsch Defense: Scandinavian Variation, Bogoljubov Variation, Erben Gambit	1. e4 Nc6 2. d4 d5 3. Nc3 g6
 B00	Nimzowitsch Defense: Scandinavian Variation, Bogoljubov Variation, Heinola-Deppe Gambit	1. e4 Nc6 2. d4 d5 3. Nc3 e5
@@ -325,6 +326,7 @@ B14	Caro-Kann Defense: Panov Attack, Fianchetto Defense	1. e4 c6 2. d4 d5 3. exd
 B14	Caro-Kann Defense: Panov Attack, Fianchetto Defense, Fianchetto Gambit	1. e4 c6 2. d4 d5 3. exd5 cxd5 4. c4 Nf6 5. Nc3 g6 6. cxd5 Bg7
 B14	Caro-Kann Defense: Panov Attack, Main Line	1. e4 c6 2. d4 d5 3. exd5 cxd5 4. c4 Nf6 5. Nc3 e6 6. Nf3 Bb4
 B15	Caro-Kann Defense	1. e4 c6 2. d4 d5 3. Nc3
+B15	Caro-Kann Defense	1. e4 c6 2. d4 d5 3. Nc3 dxe4
 B15	Caro-Kann Defense: Alekhine Gambit	1. e4 c6 2. d4 d5 3. Nc3 dxe4 4. Nxe4 Nf6 5. Bd3
 B15	Caro-Kann Defense: Campomanes Attack	1. e4 c6 2. d4 d5 3. Nc3 Nf6
 B15	Caro-Kann Defense: Forgacs Variation	1. e4 c6 2. d4 d5 3. Nc3 dxe4 4. Nxe4 Nf6 5. Nxf6+ exf6 6. Bc4

--- a/d.tsv
+++ b/d.tsv
@@ -11,7 +11,7 @@ D00	Blackmar-Diemer Gambit Accepted: Bogoljubow Defense, Studier Attack	1. d4 d5
 D00	Blackmar-Diemer Gambit Accepted: Euwe Defense	1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. f3 exf3 5. Nxf3 e6
 D00	Blackmar-Diemer Gambit Accepted: Euwe Defense, Zilbermints Gambit	1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. f3 exf3 5. Nxf3 e6 6. Bg5 Be7 7. Bd3 Nc6 8. O-O Nxd4 9. Kh1
 D00	Blackmar-Diemer Gambit Accepted: Gunderam Defense	1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. f3 exf3 5. Nxf3 Bf5
-D00	Blackmar-Diemer Gambit Accepted: Gunderam Defense, Stader Variation	1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. f3 exf3 5. Nxf3 Bf5 6. Ne5 e5 7. Be4
+D00	Blackmar-Diemer Gambit Accepted: Gunderam Defense, Stader Variation	1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. f3 exf3 5. Nxf3 Bf5 6. Ne5 e6 7. Be4
 D00	Blackmar-Diemer Gambit Accepted: Holwell Defense	1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. f3 exf3 5. Nxf3 Qd6
 D00	Blackmar-Diemer Gambit Accepted: Kaulich Defense	1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. f3 exf3 5. Nxf3 c5
 D00	Blackmar-Diemer Gambit Accepted: Pietrowsky Defense	1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. f3 exf3 5. Nxf3 Nc6

--- a/d.tsv
+++ b/d.tsv
@@ -1,8 +1,7 @@
 eco	name	pgn
 D00	Amazon Attack	1. d4 d5 2. Qd3
 D00	Blackmar-Diemer Gambit	1. d4 d5 2. e4
-D00	Blackmar-Diemer Gambit	1. d4 d5 2. e4 dxe4 3. Nc3
-D00	Blackmar-Diemer Gambit	1. d4 Nf6 2. Nc3 d5 3. e4
+D00	Blackmar-Diemer Gambit	1. d4 d5 2. e4 dxe4 3. Nc3 Nf6
 D00	Blackmar-Diemer Gambit Accepted	1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. f3 exf3
 D00	Blackmar-Diemer Gambit Accepted: Bogoljubow Defense	1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. f3 exf3 5. Nxf3 g6
 D00	Blackmar-Diemer Gambit Accepted: Bogoljubow Defense, Kloss Attack	1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. f3 exf3 5. Nxf3 g6 6. Bc4 Bg7 7. O-O O-O 8. Kh1
@@ -11,34 +10,39 @@ D00	Blackmar-Diemer Gambit Accepted: Bogoljubow Defense, Nimzowitsch Attack	1. d
 D00	Blackmar-Diemer Gambit Accepted: Bogoljubow Defense, Studier Attack	1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. f3 exf3 5. Nxf3 g6 6. Bc4 Bg7 7. O-O O-O 8. Qe1
 D00	Blackmar-Diemer Gambit Accepted: Euwe Defense	1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. f3 exf3 5. Nxf3 e6
 D00	Blackmar-Diemer Gambit Accepted: Euwe Defense, Zilbermints Gambit	1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. f3 exf3 5. Nxf3 e6 6. Bg5 Be7 7. Bd3 Nc6 8. O-O Nxd4 9. Kh1
+D00	Blackmar-Diemer Gambit Accepted: Gunderam Defense	1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. f3 exf3 5. Nxf3 Bf5
+D00	Blackmar-Diemer Gambit Accepted: Gunderam Defense, Stader Variation	1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. f3 exf3 5. Nxf3 Bf5 6. Ne5 e5 7. Be4
+D00	Blackmar-Diemer Gambit Accepted: Holwell Defense	1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. f3 exf3 5. Nxf3 b6
 D00	Blackmar-Diemer Gambit Accepted: Kaulich Defense	1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. f3 exf3 5. Nxf3 c5
 D00	Blackmar-Diemer Gambit Accepted: Pietrowsky Defense	1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. f3 exf3 5. Nxf3 Nc6
 D00	Blackmar-Diemer Gambit Accepted: Ritter Defense	1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. f3 exf3 5. Nxf3 b6
-D00	Blackmar-Diemer Gambit Accepted: Rook Pawn Defense	1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. f3 exf3 5. Nxf3 h5
 D00	Blackmar-Diemer Gambit Accepted: Ryder Gambit	1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. f3 exf3 5. Qxf3
 D00	Blackmar-Diemer Gambit Accepted: Schlutter Defense	1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. f3 exf3 5. Nxf3 Nbd7
-D00	Blackmar-Diemer Gambit Accepted: Tartakower Variation	1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. f3 exf3 5. Nxf3 Bf5
-D00	Blackmar-Diemer Gambit Accepted: Teichmann Variation	1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. f3 exf3 5. Nxf3 Bg4
+D00	Blackmar-Diemer Gambit Accepted: Teichmann Defense	1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. f3 exf3 5. Nxf3 Bg4
+D00	Blackmar-Diemer Gambit Accepted: Teichmann Defense, Ciesielski Variation	1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. f3 exf3 5. Nxf3 Bg4 6. h3 Bxf3 7. Qxf3 c6 8. Qf2
+D00	Blackmar-Diemer Gambit Accepted: Teichmann Defense, Classical Variation	1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. f3 exf3 5. Nxf3 Bg4 6. h3 Bxf3 7. Qxf3 c6 8. Be3
+D00	Blackmar-Diemer Gambit Accepted: Teichmann Defense, Seidel-Hall Attack	1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. f3 exf3 5. Nxf3 Bg4 6. h3 Bxf3 7. Qxf3 c6 8. g4
 D00	Blackmar-Diemer Gambit Accepted: Ziegler Defense	1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. f3 exf3 5. Nxf3 c6
 D00	Blackmar-Diemer Gambit Declined: Brombacher Countergambit	1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. f3 c5
 D00	Blackmar-Diemer Gambit Declined: Elbert Countergambit	1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. f3 e5
+D00	Blackmar-Diemer Gambit Declined: Gedult Defense	1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. f3 a6
 D00	Blackmar-Diemer Gambit Declined: Lamb Defense	1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. f3 Nc6
-D00	Blackmar-Diemer Gambit Declined: Langeheinecke Defense	1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. f3 e3
+D00	Blackmar-Diemer Gambit Declined: Langeheinicke Defense	1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. f3 e3
 D00	Blackmar-Diemer Gambit Declined: O'Kelly Defense	1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. f3 c6
-D00	Blackmar-Diemer Gambit Declined: Vienna Variation	1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. f3 Bf5
-D00	Blackmar-Diemer Gambit Declined: Weinsbach Declination	1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. f3 e6
+D00	Blackmar-Diemer Gambit Declined: Vienna Defense	1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. f3 Bf5
+D00	Blackmar-Diemer Gambit Declined: Weinsbach Defense	1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. f3 e6
+D00	Blackmar-Diemer Gambit: Blackmar Gambit	1. d4 d5 2. e4 dxe4 3. f3
 D00	Blackmar-Diemer Gambit: Diemer-Rosenberg Attack	1. d4 d5 2. e4 dxe4 3. Be3
 D00	Blackmar-Diemer Gambit: Fritz Attack	1. d4 d5 2. e4 dxe4 3. Bc4
-D00	Blackmar-Diemer Gambit: Gedult Gambit	1. d4 d5 2. e4 dxe4 3. f3
-D00	Blackmar-Diemer Gambit: Grosshans Defense	1. d4 d5 2. e4 dxe4 3. Nc3 Bd7
 D00	Blackmar-Diemer Gambit: Lemberger Countergambit	1. d4 d5 2. e4 dxe4 3. Nc3 e5
-D00	Blackmar-Diemer Gambit: Lemberger Countergambit, Diemer Attack	1. d4 d5 2. e4 dxe4 3. Nc3 e5 4. Be3
 D00	Blackmar-Diemer Gambit: Lemberger Countergambit, Endgame Variation	1. d4 d5 2. e4 dxe4 3. Nc3 e5 4. dxe5
-D00	Blackmar-Diemer Gambit: Lemberger Countergambit, Rassmussen Attack	1. d4 d5 2. e4 dxe4 3. Nc3 e5 4. Nge2
-D00	Blackmar-Diemer Gambit: Lemberger Countergambit, Simple Variation	1. d4 d5 2. e4 dxe4 3. Nc3 e5 4. Nxe4
+D00	Blackmar-Diemer Gambit: Lemberger Countergambit, Lange Gambit	1. d4 d5 2. e4 dxe4 3. Nc3 e5 4. Nxe4
+D00	Blackmar-Diemer Gambit: Lemberger Countergambit, Rasmussen Attack	1. d4 d5 2. e4 dxe4 3. Nc3 e5 4. Nge2
 D00	Blackmar-Diemer Gambit: Lemberger Countergambit, Sneiders Attack	1. d4 d5 2. e4 dxe4 3. Nc3 e5 4. Qh5
+D00	Blackmar-Diemer Gambit: Lemberger Countergambit, Soller Attack	1. d4 d5 2. e4 dxe4 3. Nc3 e5 4. Be3
 D00	Blackmar-Diemer Gambit: Netherlands Variation	1. d4 d5 2. e4 dxe4 3. Nc3 f5
 D00	Blackmar-Diemer Gambit: Rasa-Studier Gambit	1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. Be3
+D00	Blackmar-Diemer Gambit: Reversed Albin Countergambit	1. d4 d5 2. e4 dxe4 3. Nc3 c5
 D00	Blackmar-Diemer Gambit: Zeller Defense	1. d4 d5 2. e4 dxe4 3. Nc3 Bf5
 D00	Blackmar-Diemer Gambit: Zeller Defense, Soller Attack	1. d4 d5 2. e4 dxe4 3. Nc3 Bf5 4. f3 Nf6 5. Bc4
 D00	Blackmar-Diemer Gambit: von Popiel Gambit	1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. Bg5
@@ -54,7 +58,7 @@ D00	Queen's Pawn Game: Chigorin Variation, Fianchetto Defense	1. d4 g6 2. Nf3 Bg
 D00	Queen's Pawn Game: Chigorin Variation, Irish Gambit	1. d4 d5 2. Nc3 c5
 D00	Queen's Pawn Game: Chigorin Variation, Shaviliuk Gambit	1. d4 d5 2. Nc3 e5
 D00	Queen's Pawn Game: Chigorin Variation, Shropshire Defense	1. d4 d5 2. Nc3 h5
-D00	Queen's Pawn Game: Hübsch Gambit	1. d4 Nf6 2. Nc3 d5 3. e4 Nxe4
+D00	Queen's Pawn Game: Hübsch Gambit	1. d4 Nf6 2. Nc3 d5 3. e4
 D00	Queen's Pawn Game: Levitsky Attack	1. d4 d5 2. Bg5
 D00	Queen's Pawn Game: Levitsky Attack, Welling Variation	1. d4 d5 2. Bg5 Bg4
 D00	Queen's Pawn Game: Mason Attack	1. d4 d5 2. f4

--- a/d.tsv
+++ b/d.tsv
@@ -12,7 +12,7 @@ D00	Blackmar-Diemer Gambit Accepted: Euwe Defense	1. d4 d5 2. e4 dxe4 3. Nc3 Nf6
 D00	Blackmar-Diemer Gambit Accepted: Euwe Defense, Zilbermints Gambit	1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. f3 exf3 5. Nxf3 e6 6. Bg5 Be7 7. Bd3 Nc6 8. O-O Nxd4 9. Kh1
 D00	Blackmar-Diemer Gambit Accepted: Gunderam Defense	1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. f3 exf3 5. Nxf3 Bf5
 D00	Blackmar-Diemer Gambit Accepted: Gunderam Defense, Stader Variation	1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. f3 exf3 5. Nxf3 Bf5 6. Ne5 e5 7. Be4
-D00	Blackmar-Diemer Gambit Accepted: Holwell Defense	1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. f3 exf3 5. Nxf3 b6
+D00	Blackmar-Diemer Gambit Accepted: Holwell Defense	1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. f3 exf3 5. Nxf3 Qd6
 D00	Blackmar-Diemer Gambit Accepted: Kaulich Defense	1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. f3 exf3 5. Nxf3 c5
 D00	Blackmar-Diemer Gambit Accepted: Pietrowsky Defense	1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. f3 exf3 5. Nxf3 Nc6
 D00	Blackmar-Diemer Gambit Accepted: Ritter Defense	1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. f3 exf3 5. Nxf3 b6

--- a/d.tsv
+++ b/d.tsv
@@ -11,7 +11,7 @@ D00	Blackmar-Diemer Gambit Accepted: Bogoljubow Defense, Studier Attack	1. d4 d5
 D00	Blackmar-Diemer Gambit Accepted: Euwe Defense	1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. f3 exf3 5. Nxf3 e6
 D00	Blackmar-Diemer Gambit Accepted: Euwe Defense, Zilbermints Gambit	1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. f3 exf3 5. Nxf3 e6 6. Bg5 Be7 7. Bd3 Nc6 8. O-O Nxd4 9. Kh1
 D00	Blackmar-Diemer Gambit Accepted: Gunderam Defense	1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. f3 exf3 5. Nxf3 Bf5
-D00	Blackmar-Diemer Gambit Accepted: Gunderam Defense, Stader Variation	1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. f3 exf3 5. Nxf3 Bf5 6. Ne5 e6 7. Be4
+D00	Blackmar-Diemer Gambit Accepted: Gunderam Defense, Stader Variation	1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. f3 exf3 5. Nxf3 Bf5 6. Ne5 e6 7. g4 Be4
 D00	Blackmar-Diemer Gambit Accepted: Holwell Defense	1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. f3 exf3 5. Nxf3 Qd6
 D00	Blackmar-Diemer Gambit Accepted: Kaulich Defense	1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. f3 exf3 5. Nxf3 c5
 D00	Blackmar-Diemer Gambit Accepted: Pietrowsky Defense	1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. f3 exf3 5. Nxf3 Nc6


### PR DESCRIPTION
The page numbers refer to the extensive book [The Blackmar-Diemer Gambit](https://www.amazon.com/Blackmar-Diemer-Gambit-Christoph-Scheerer-ebook/dp/B005KN6UO2) by Christoph Scheerer.

# Transpositions

- Removed `1. d4 d5 2. e4 dxe4 3. Nc3` called `Blackmar-Diemer Gambit`. (There is no other sensible sequence of moves reaching `1. d4 d5 2. e4 dxe4 3. Nc3` without reaching `1. d4 d5 2. e4` first.)


## `Hübsch Gambit`

- Removed `1. d4 Nf6 2. Nc3 d5 3. e4 Nxe4` called `Queen's Pawn Game: Hübsch Gambit`.
- Renamed `1. d4 Nf6 2. Nc3 d5 3. e4` from `Blackmar-Diemer Gambit` to `Queen's Pawn Game: Hübsch Gambit`.
- Added `1. d4 d5 2. e4 dxe4 3. Nc3 Nf6` called `Blackmar-Diemer Gambit`.

Currently, we have the following (awkward) sequence of transpositions before reaching the starting position of the `Hübsch Gambit` after `1. d4 Nf6 2. Nc3 d5 3. e4 Nxe4`:

`1. d4 { Queen's Pawn Game } 1... Nf6 { Indian Defense } 2. Nc3 d5 { Queen's Pawn Game: Chigorin Variation } 3. e4 { Blackmar-Diemer Gambit } 3... Nxe4 { Queen's Pawn Game: Hübsch Gambit }`

We transpose out and into the `Queen's Pawn Game` a total of two times. Since `3. e4` is gambitting the pawn, the `Hübsch Gambit` should start after `1. d4 Nf6 2. Nc3 d5 3. e4`. The result is the following (tidier) sequence of transpositions, where we only leave and re-enter the `Queen's Pawn Game` once:

`1. d4 { Queen's Pawn Game } 1... Nf6 { Indian Defense } 2. Nc3 d5 { Queen's Pawn Game: Chigorin Variation } 3. e4 { Queen's Pawn Game: Hübsch Gambit } 3... Nxe4`

Note that taking the pawn on e5 with `3... dxe4` transposes into the main line of the `Blackmar-Diemer Gambit` after `1. d4 d5 2. e4 dxe4 3. Nc3 Nf6`:

`1. d4 { Queen's Pawn Game } 1... Nf6 { Indian Defense } 2. Nc3 d5 { Queen's Pawn Game: Chigorin Variation } 3. e4 { Queen's Pawn Game: Hübsch Gambit } 3... dxe4 { Blackmar-Diemer Gambit }`


## Transpositions into other openings

- Added `1. e4 c6 2. d4 d5 3. Nc3 dxe4` called `Caro-Kann Defense` [p.51]. (Transposing from `1. d4 d5 2. e4 dxe4 3. Nc3 c6`.)
- Added `1. e4 Nc6 2. d4 d5 3. Nc3 dxe4` called `Nimzowitsch Defense: Scandinavian Variation, Bogoljubov Variation` [p.54]. (Transposing from `1. d4 d5 2. e4 dxe4 3. Nc3 Nc6`.)


# BDG Variations

I shortened the opening names for readability.

- Renamed `1. d4 d5 2. e4 dxe4 3. f3` from `Gedult Gambit` to `Blackmar Gambit` [p.13].
- Renamed `1. d4 d5 2. e4 dxe4 3. Nc3 e5 4. Be3` from `Diemer Attack` to `Soller Attack` [p.15].
- Renamed `1. d4 d5 2. e4 dxe4 3. Nc3 e5 4. Nge2` from `Rassmussen Attack` to `Rasmussen Attack` [p.17].
- Renamed `1. d4 d5 2. e4 dxe4 3. Nc3 e5 4. Nxe4` from `Simple Variation` to `Lange Gambit` [p.36].
- Added `1. d4 d5 2. e4 dxe4 3. Nc3 c5` called `Reversed Albin Countergambit` [p.52].
- Renamed `1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. f3 e6` from `Weinsbach Declination` to `Weinsbach Defense` [p.71].
- Renamed `1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. f3 e3` from `Langeheinecke Defense` to `Langeheinicke Defense` [p.84].
- Renamed `1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. f3 Bf5` from `Vienna Variation` to `Vienna Defense` [p.103].
- Added `1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. f3 exf3 5. Nxf3 Qd6` called `Holwell Defense` [p.131].
- Added `1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. f3 a6` called `Gedult Defense` [p.134].
- Renamed `1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. f3 exf3 5. Nxf3 Bf5` from `Tartakower Variation` to `Gunderam Defense` [p.206].
- Added `1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. f3 exf3 5. Nxf3 Bf5 6. Ne5 e5 7. Be4` called `Gunderam Defense, Stader Variation` [p.213].
- Renamed `1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. f3 exf3 5. Nxf3 Bg4` from `Teichmann Variation` to `Teichmann Defense` [p.233].
- Added `1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. f3 exf3 5. Nxf3 Bg4 6. h3 Bxf3 7. Qxf3 c6 8. Qf2` called `Teichmann Defense, Ciesielski Variation` [p.256].
- Added `1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. f3 exf3 5. Nxf3 Bg4 6. h3 Bxf3 7. Qxf3 c6 8. g4` called `Teichmann Defense, Seidel-Hall Attack` [p.260].
- Added `1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. f3 exf3 5. Nxf3 Bg4 6. h3 Bxf3 7. Qxf3 c6 8. Be3` called `Teichmann Defense, Classical Variation` [p.266].


# Zero Value Lines

The following lines have no practical / theoretical / historical value and are pretty much never played:

- Removed `1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. f3 exf3 5. Nxf3 h5` called `Blackmar-Diemer Gambit Accepted: Rook Pawn Defense`.
- Removed `1. d4 d5 2. e4 dxe4 3. Nc3 Bd7` called `Blackmar-Diemer Gambit: Grosshans Defense`.


# Obscure Lines

I couldn't find any information about the following lines and they don't seem to have zero value. (Maybe someone else wants to look into this.)

- `1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. f3 exf3 5. Nxf3 e6 6. Bg5 Be7 7. Bd3 Nc6 8. O-O Nxd4 9. Kh1` called `Blackmar-Diemer Gambit Accepted: Euwe Defense, Zilbermints Gambit`.
- `1. d4 d5 2. e4 dxe4 3. Be3` called `Blackmar-Diemer Gambit: Diemer-Rosenberg Attack`.
- `1. d4 d5 2. e4 dxe4 3. Bc4` called `Blackmar-Diemer Gambit: Fritz Attack`.
- `1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. Be3` called `Blackmar-Diemer Gambit: Rasa-Studier Gambit`.
- `1. d4 d5 2. e4 dxe4 3. Nc3 Bf5 4. f3 Nf6 5. Bc4` called `Blackmar-Diemer Gambit: Zeller Defense, Soller Attack`.
- `1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. Bg5` called `Blackmar-Diemer Gambit: von Popiel Gambit`.
- `1. d4 d5 2. e4 dxe4 3. Nc3 Nf6 4. Bg5 Bf5 5. Bxf6 exf6 6. g4 Bg6 7. Qe2 Bb4 8. Qb5+` called `Blackmar-Diemer Gambit: von Popiel Gambit, Zilbermints Variation`.