### PR TITLE
Updated Semi-Tarrasch vs Tarrasch

### DIFF
--- a/d.tsv
+++ b/d.tsv
@@ -270,7 +270,7 @@ D31	Semi-Slav Defense: Noteboom Variation, Anti-Noteboom Gambit	1. d4 d5 2. c4 e
 D31	Semi-Slav Defense: Noteboom Variation, Anti-Noteboom Variation	1. d4 d5 2. c4 e6 3. Nc3 c6 4. Nf3 dxc4 5. Bg5
 D31	Semi-Slav Defense: Noteboom Variation, Anti-Noteboom Variation, Belyavsky Line	1. d4 d5 2. c4 e6 3. Nc3 c6 4. Nf3 dxc4 5. Bg5 f6
 D32	Queen's Gambit Declined: Tarrasch Defense	1. d4 d5 2. c4 e6 3. Nc3 c5 4. cxd5 exd5
-D32	Tarrasch Defense	1. d4 d5 2. c4 e6 3. Nc3 Nf6 4. Nf3 c5 6. cxd5 exd5
+D32	Tarrasch Defense	1. d4 d5 2. c4 e6 3. Nc3 Nf6 4. Nf3 c5 5. cxd5 exd5
 D32	Tarrasch Defense	1. d4 d5 2. c4 e6 3. Nc3 c5
 D32	Tarrasch Defense: Grünfeld Gambit	1. d4 d5 2. c4 e6 3. Nc3 c5 4. cxd5 exd5 5. Nf3 Nc6 6. dxc5 d4 7. Na4 b5
 D32	Tarrasch Defense: Marshall Gambit	1. d4 d5 2. c4 e6 3. Nc3 c5 4. cxd5 exd5 5. e4

--- a/d.tsv
+++ b/d.tsv
@@ -270,6 +270,7 @@ D31	Semi-Slav Defense: Noteboom Variation, Anti-Noteboom Gambit	1. d4 d5 2. c4 e
 D31	Semi-Slav Defense: Noteboom Variation, Anti-Noteboom Variation	1. d4 d5 2. c4 e6 3. Nc3 c6 4. Nf3 dxc4 5. Bg5
 D31	Semi-Slav Defense: Noteboom Variation, Anti-Noteboom Variation, Belyavsky Line	1. d4 d5 2. c4 e6 3. Nc3 c6 4. Nf3 dxc4 5. Bg5 f6
 D32	Queen's Gambit Declined: Tarrasch Defense	1. d4 d5 2. c4 e6 3. Nc3 c5 4. cxd5 exd5
+D32	Tarrasch Defense	1. d4 d5 2. c4 e6 3. Nc3 Nf6 4. Nf3 c5 6. cxd5 exd5
 D32	Tarrasch Defense	1. d4 d5 2. c4 e6 3. Nc3 c5
 D32	Tarrasch Defense: Grünfeld Gambit	1. d4 d5 2. c4 e6 3. Nc3 c5 4. cxd5 exd5 5. Nf3 Nc6 6. dxc5 d4 7. Na4 b5
 D32	Tarrasch Defense: Marshall Gambit	1. d4 d5 2. c4 e6 3. Nc3 c5 4. cxd5 exd5 5. e4


### PR DESCRIPTION
Currently the position after 
1. d4 d5 2. c4 e6 3. Nc3 Nf6 4. Nf3 c5 5. cxd5 exd5 is listed as the semi-tarrasch when it is a tarrasch. I added a line to fix that, so that now after 5. cxd5 exd5 the position would be reclassified as a Tarrasch.