### PR TITLE
+B30 Silician Defense: Portsmouth Gambit

### DIFF
--- a/b.tsv
+++ b/b.tsv
@@ -493,6 +493,7 @@ B30	Sicilian Defense: Closed, Anti-Sveshnikov Variation, Kharlov-Kramnik Line	1.
 B30	Sicilian Defense: Nyezhmetdinov-Rossolimo Attack	1. e4 c5 2. Nf3 Nc6 3. Bb5
 B30	Sicilian Defense: Nyezhmetdinov-Rossolimo Attack, San Francisco Gambit	1. e4 c5 2. Nf3 Nc6 3. Bb5 Na5 4. b4
 B30	Sicilian Defense: Old Sicilian	1. e4 c5 2. Nf3 Nc6
+B30	Sicilian Defense: Portsmouth Gambit	1. e4 c5 2. Nf3 Nc6 3. b4
 B30	Sicilian Defense: Rossolimo Variation, Brooklyn Retreat Defense	1. e4 c5 2. Nf3 Nc6 3. Bb5 Nb8
 B31	Sicilian Defense: Nyezhmetdinov-Rossolimo Attack, Fianchetto Variation	1. e4 c5 2. Nf3 Nc6 3. Bb5 g6
 B31	Sicilian Defense: Nyezhmetdinov-Rossolimo Attack, Fianchetto Variation, Gufeld Gambit	1. e4 c5 2. Nf3 Nc6 3. Bb5 g6 4. O-O Bg7 5. c3 e5 6. d4


### PR DESCRIPTION
When doing "1. e4 c5 2. Nf3 Nc6 3. b4" in analysis, we get the Wikibook page of the Portsmouth Gambit. It would be more than reasonable to have it in the chess openings I believe.

Portsmouth Gambit is an established named variant of the Wing Gambit, just used later in a particular Silician line. If you google you may find it named "Smirnov Gambit" but it makes no sense, as the GM was born after the naming of this Gambit.

One blog post that talks about it : https://portsmouthgambit.wordpress.com/2011/02/04/the-portsmouth-gambit/