### PR TITLE
Indian Defense: Anti-Grünfeld, Basman-Williams Attack

### DIFF
--- a/e.tsv
+++ b/e.tsv
@@ -173,6 +173,7 @@ E60	Indian Defense: Anti-Grünfeld, Adorjan Gambit	1. d4 Nf6 2. c4 g6 3. d5 b5
 E60	Indian Defense: Anti-Grünfeld, Advance Variation	1. d4 Nf6 2. c4 g6 3. d5
 E60	Indian Defense: Anti-Grünfeld, Alekhine Variation	1. d4 Nf6 2. c4 g6 3. f3
 E60	Indian Defense: Anti-Grünfeld, Alekhine Variation, Leko Gambit	1. d4 Nf6 2. c4 g6 3. f3 e5
+E60	Indian Defense: Anti-Grünfeld, Basman-Williams Attack	1. d4 Nf6 2. c4 g6 3. h4
 E60	Indian Defense: King's Indian Variation, Fianchetto Variation	1. d4 Nf6 2. c4 g6 3. g3 Bg7 4. Bg2
 E60	Indian Defense: West Indian Defense	1. d4 Nf6 2. c4 g6
 E60	King's Indian Defense: Fianchetto Variation, Immediate Fianchetto	1. d4 Nf6 2. c4 g6 3. g3


### PR DESCRIPTION
Adding the Basman-Williams Attack as referred to e.g. by Carsten Hansen in the eponymous book, cf. https://lichess.org/@/Minckwitz/blog/review-the-basman-williams-attack-by-carsten-hansen/ZOnJsOTG