### PR TITLE
conditional python command python3 or python

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PYTHON = python3
+PYTHON := $(shell command -v python3 || command -v python)
 
 all: dist/a.tsv dist/b.tsv dist/c.tsv dist/d.tsv dist/e.tsv
 


### PR DESCRIPTION
I don't know much python so bear with me. Instead of `python3` the command I have to use is `python`. I found out that I needed to rename my `python.exe` to `python3.exe` to fix this.  
Anyway how about selecting whether python3 or python in makefile conditionally?
ignore if this doesn't make sense.