### PR TITLE
Dutch stonewall vs classical

### DIFF
--- a/a.tsv
+++ b/a.tsv
@@ -690,7 +690,7 @@ A91	Dutch Defense: Classical Variation	1. d4 e6 2. c4 f5 3. g3 Nf6 4. Bg2 Be7
 A91	Dutch Defense: Classical Variation, Blackburne Attack	1. d4 e6 2. c4 f5 3. g3 Nf6 4. Bg2 Be7 5. Nh3
 A92	Dutch Defense: Alekhine Variation	1. d4 e6 2. c4 f5 3. g3 Nf6 4. Bg2 Be7 5. Nf3 O-O 6. O-O Ne4
 A92	Dutch Defense: Classical Variation	1. d4 e6 2. c4 f5 3. g3 Nf6 4. Bg2 Be7 5. Nf3 O-O
-A92	Dutch Defense: Stonewall Variation  1. d4 e6 2. Nf3 f5 3. g3 Nf6 4. Bg2 Be7 5. O-O O-O 6. c4 d5 7. Nc3
+A92	Dutch Defense: Stonewall Variation	1. d4 e6 2. Nf3 f5 3. g3 Nf6 4. Bg2 Be7 5. O-O O-O 6. c4 d5 7. Nc3
 A92	Dutch Defense: Stonewall Variation	1. d4 e6 2. c4 f5 3. g3 Nf6 4. Bg2 Be7 5. Nf3 d5 6. O-O O-O
 A93	Dutch Defense: Stonewall Variation, Botvinnik Variation	1. d4 e6 2. c4 f5 3. g3 Nf6 4. Bg2 Be7 5. Nf3 d5 6. O-O O-O 7. b3
 A94	Dutch Defense: Stonewall Variation	1. d4 e6 2. c4 f5 3. g3 Nf6 4. Bg2 Be7 5. Nf3 d5 6. O-O O-O 7. b3 c6 8. Ba3

--- a/a.tsv
+++ b/a.tsv
@@ -690,12 +690,12 @@ A91	Dutch Defense: Classical Variation	1. d4 e6 2. c4 f5 3. g3 Nf6 4. Bg2 Be7
 A91	Dutch Defense: Classical Variation, Blackburne Attack	1. d4 e6 2. c4 f5 3. g3 Nf6 4. Bg2 Be7 5. Nh3
 A92	Dutch Defense: Alekhine Variation	1. d4 e6 2. c4 f5 3. g3 Nf6 4. Bg2 Be7 5. Nf3 O-O 6. O-O Ne4
 A92	Dutch Defense: Classical Variation	1. d4 e6 2. c4 f5 3. g3 Nf6 4. Bg2 Be7 5. Nf3 O-O
-A92	Dutch Defense: Stonewall	1. d4 e6 2. Nf3 f5 3. g3 Nf6 4. Bg2 Be7 5. O-O O-O 6. c4 d5 7. Nc3
+A92	Dutch Defense: Stonewall Variation  1. d4 e6 2. Nf3 f5 3. g3 Nf6 4. Bg2 Be7 5. O-O O-O 6. c4 d5 7. Nc3
 A92	Dutch Defense: Stonewall Variation	1. d4 e6 2. c4 f5 3. g3 Nf6 4. Bg2 Be7 5. Nf3 d5 6. O-O O-O
-A93	Dutch Defense: Classical Variation, Stonewall Variation, Botvinnik Variation	1. d4 e6 2. c4 f5 3. g3 Nf6 4. Bg2 Be7 5. Nf3 d5 6. O-O O-O 7. b3
-A94	Dutch Defense: Classical Variation, Stonewall Variation	1. d4 e6 2. c4 f5 3. g3 Nf6 4. Bg2 Be7 5. Nf3 d5 6. O-O O-O 7. b3 c6 8. Ba3
-A95	Dutch Defense: Classical Variation, Stonewall Variation	1. d4 e6 2. c4 f5 3. g3 Nf6 4. Bg2 d5 5. Nf3 Be7 6. O-O O-O 7. Nc3 c6
-A95	Dutch Defense: Stonewall, Chekhover Variation	1. d4 f5 2. c4 Nf6 3. g3 e6 4. Bg2 Be7 5. Nf3 O-O 6. O-O d5 7. Nc3 c6 8. Qc2 Qe8 9. Bg5
+A93	Dutch Defense: Stonewall Variation, Botvinnik Variation	1. d4 e6 2. c4 f5 3. g3 Nf6 4. Bg2 Be7 5. Nf3 d5 6. O-O O-O 7. b3
+A94	Dutch Defense: Stonewall Variation	1. d4 e6 2. c4 f5 3. g3 Nf6 4. Bg2 Be7 5. Nf3 d5 6. O-O O-O 7. b3 c6 8. Ba3
+A95	Dutch Defense: Stonewall Variation	1. d4 e6 2. c4 f5 3. g3 Nf6 4. Bg2 d5 5. Nf3 Be7 6. O-O O-O 7. Nc3 c6
+A95	Dutch Defense: Stonewall Variation, Chekhover Variation	1. d4 f5 2. c4 Nf6 3. g3 e6 4. Bg2 Be7 5. Nf3 O-O 6. O-O d5 7. Nc3 c6 8. Qc2 Qe8 9. Bg5
 A96	Dutch Defense: Classical Variation	1. d4 e6 2. c4 f5 3. g3 Nf6 4. Bg2 Be7 5. Nf3 O-O 6. O-O d6
 A96	Dutch Defense: Classical Variation, Buenos Aires Variation	1. d4 e6 2. c4 f5 3. g3 Nf6 4. Bg2 Be7 5. Nf3 O-O 6. O-O d6 7. Nc3 a5
 A96	Dutch Defense: Classical Variation, Huisl Variation	1. d4 e6 2. c4 f5 3. g3 Nf6 4. Bg2 Be7 5. Nf3 O-O 6. O-O d6 7. Nc3 Ne4


### PR DESCRIPTION
Some lines were named `Dutch Defense: Classical Variation, Stonewall Variation` which is completely incorrect, Classical and Stonewall are two different variations in the Dutch. In the Classical Black moves the d-pawn to d6, while in the Stonewall it's moved to d5.

Sources:
1. [Wikpedia](https://en.wikipedia.org/wiki/Pawn_structure#Stonewall_formation)
2. [The Modernized Stonewall Defense](https://www.newinchess.com/the-modernized-stonewall-defense)
3. [The Aggressive Classical Dutch](https://en.chessbase.com/post/the-aggressive-classical-dutch)

Also, I've added `Variation` to two Stonewall codes (A92 and A95), just for consistency.

And finally, I couldn't find references to the Stonewall Variation, Botvinnik Variation, but if A93 is called this way then A94 should too (as is the same line with just two half-moves more). I didn't add this change, but can do it if you agree.