### PR TITLE
Alekhine Defense: Two Pawns Attack, Tate Variation

### DIFF
--- a/b.tsv
+++ b/b.tsv
@@ -153,6 +153,7 @@ B02	Alekhine Defense: The Squirrel	1. e4 Nf6 2. e5 Nd5 3. c4 Nf4
 B02	Alekhine Defense: Two Pawns Attack	1. e4 Nf6 2. e5 Nd5 3. c4
 B02	Alekhine Defense: Two Pawns Attack, Lasker Variation	1. e4 Nf6 2. e5 Nd5 3. c4 Nb6 4. c5
 B02	Alekhine Defense: Two Pawns Attack, Mikenas Variation	1. e4 Nf6 2. e5 Nd5 3. c4 Nb6 4. c5 Nd5 5. Bc4 e6 6. Nc3 d6
+B02	Alekhine Defense: Two Pawns Attack, Tate Variation	1. e4 Nf6 2. e5 Nd5 3. c4 Nb6 4. a4
 B02	Alekhine Defense: Welling Variation	1. e4 Nf6 2. e5 Nd5 3. b3
 B03	Alekhine Defense	1. e4 Nf6 2. e5 Nd5 3. d4
 B03	Alekhine Defense	1. e4 Nf6 2. e5 Nd5 3. d4 d6


### PR DESCRIPTION
The Tate Variation of the Alekhine Defence as it is referred to e.g. by Wikipedia https://en.wikipedia.org/wiki/Alekhine%27s_Defence and Bryan Tillis's Chessable Course https://www.chessable.com/alekhine-defense-the-dark-knight-rises/course/15881/