### PR TITLE
Add bongcloud variations

### DIFF
--- a/c.tsv
+++ b/c.tsv
@@ -178,7 +178,7 @@ C19	French Defense: Winawer Variation, Poisoned Pawn Variation, Paoli Variation	
 C19	French Defense: Winawer Variation, Positional Variation	1. e4 e6 2. d4 d5 3. Nc3 Bb4 4. e5 c5 5. a3 Bxc3+ 6. bxc3 Ne7 7. Nf3
 C20	Barnes Opening: Walkerling	1. f3 e5 2. e4 Nf6 3. Bc4
 C20	Bongcloud Attack	1. e4 e5 2. Ke2
-C20    Symmetrical/Double Bongcloud    1. e4 e5 2. Ke2 Ke7
+C20     Symmetrical/Double Bongcloud    1. e4 e5 2. Ke2 Ke7
 C20	Center Game	1. e4 e5 2. d4
 C20	English Opening: The Whale	1. e4 e5 2. c4
 C20	King's Pawn Game	1. e4 e5

--- a/c.tsv
+++ b/c.tsv
@@ -178,7 +178,7 @@ C19	French Defense: Winawer Variation, Poisoned Pawn Variation, Paoli Variation	
 C19	French Defense: Winawer Variation, Positional Variation	1. e4 e6 2. d4 d5 3. Nc3 Bb4 4. e5 c5 5. a3 Bxc3+ 6. bxc3 Ne7 7. Nf3
 C20	Barnes Opening: Walkerling	1. f3 e5 2. e4 Nf6 3. Bc4
 C20	Bongcloud Attack	1. e4 e5 2. Ke2
-C20 Symmetrical/Double Bongcloud 1. e4 e5 2. Ke2 Ke7
+C20    Symmetrical/Double Bongcloud    1. e4 e5 2. Ke2 Ke7
 C20	Center Game	1. e4 e5 2. d4
 C20	English Opening: The Whale	1. e4 e5 2. c4
 C20	King's Pawn Game	1. e4 e5

--- a/c.tsv
+++ b/c.tsv
@@ -178,7 +178,7 @@ C19	French Defense: Winawer Variation, Poisoned Pawn Variation, Paoli Variation	
 C19	French Defense: Winawer Variation, Positional Variation	1. e4 e6 2. d4 d5 3. Nc3 Bb4 4. e5 c5 5. a3 Bxc3+ 6. bxc3 Ne7 7. Nf3
 C20	Barnes Opening: Walkerling	1. f3 e5 2. e4 Nf6 3. Bc4
 C20	Bongcloud Attack	1. e4 e5 2. Ke2
-C20     Symmetrical/Double Bongcloud    1. e4 e5 2. Ke2 Ke7
+C20	Double Bongcloud	1. e4 e5 2. Ke2 Ke7
 C20	Center Game	1. e4 e5 2. d4
 C20	English Opening: The Whale	1. e4 e5 2. c4
 C20	King's Pawn Game	1. e4 e5

--- a/c.tsv
+++ b/c.tsv
@@ -178,6 +178,7 @@ C19	French Defense: Winawer Variation, Poisoned Pawn Variation, Paoli Variation	
 C19	French Defense: Winawer Variation, Positional Variation	1. e4 e6 2. d4 d5 3. Nc3 Bb4 4. e5 c5 5. a3 Bxc3+ 6. bxc3 Ne7 7. Nf3
 C20	Barnes Opening: Walkerling	1. f3 e5 2. e4 Nf6 3. Bc4
 C20	Bongcloud Attack	1. e4 e5 2. Ke2
+C20 Symmetrical/Double Bongcloud 1. e4 e5 2. Ke2 Ke7
 C20	Center Game	1. e4 e5 2. d4
 C20	English Opening: The Whale	1. e4 e5 2. c4
 C20	King's Pawn Game	1. e4 e5

--- a/c.tsv
+++ b/c.tsv
@@ -179,6 +179,7 @@ C19	French Defense: Winawer Variation, Positional Variation	1. e4 e6 2. d4 d5 3.
 C20	Barnes Opening: Walkerling	1. f3 e5 2. e4 Nf6 3. Bc4
 C20	Bongcloud Attack	1. e4 e5 2. Ke2
 C20	Double Bongcloud	1. e4 e5 2. Ke2 Ke7
+C20	Lil Bongcloud Attack	1. e3 e5 2. Ke2
 C20	Center Game	1. e4 e5 2. d4
 C20	English Opening: The Whale	1. e4 e5 2. c4
 C20	King's Pawn Game	1. e4 e5


### PR DESCRIPTION
I added some other bongcloud variations.

- Double Bongcloud
- Lil/baby bongcloud

I was going to add the Hammerschlag Variation:

<img width="355" alt="image" src="https://github.com/lichess-org/chess-openings/assets/68472469/bf6daa19-ea8f-40d8-b32b-61061456d28f">

But there is an opening called the pork-chop opening (just a different name for the Hammerchlag) that is already registered on lichess. It's possible that we could change the name; But, that's debatable...