### PR TITLE
relocate A00 Van Geet Opening: Caro-Kann Variation, St. Patrick's Attack to the other Caro-Kann lines

### DIFF
--- a/a.tsv
+++ b/a.tsv
@@ -100,7 +100,6 @@ A00	Valencia Opening	1. d3 e5 2. Nd2
 A00	Van Geet Opening	1. Nc3
 A00	Van Geet Opening: Battambang Variation	1. a3 e5 2. Nc3
 A00	Van Geet Opening: Billockus-Johansen Gambit	1. Nc3 e5 2. Nf3 Bc5
-A00	Van Geet Opening: Caro-Kann Variation, St. Patrick's Attack	1. Nc3 d5 2. e4 c6 3. h3
 A00	Van Geet Opening: Damhaug Gambit	1. Nc3 d5 2. f4 e5
 A00	Van Geet Opening: Dougherty Gambit	1. Nc3 d5 2. e4 dxe4 3. f3
 A00	Van Geet Opening: Dunst-Perrenet Gambit	1. Nc3 d5 2. e4 dxe4 3. d3

--- a/b.tsv
+++ b/b.tsv
@@ -285,8 +285,8 @@ B10	Caro-Kann Defense: Labahn Attack, Polish Variation	1. e4 c6 2. b4 e5 3. Bb2
 B10	Caro-Kann Defense: Scorpion-Horus Gambit	1. e4 c6 2. Nc3 d5 3. d3 dxe4 4. Bg5
 B10	Caro-Kann Defense: Spike Variation	1. e4 c6 2. g4
 B10	Caro-Kann Defense: Spike Variation, Scorpion-Grob Gambit	1. e4 c6 2. g4 d5 3. Nc3 dxe4 4. d3
-B10	Caro-Kann Defense: Toikkanen Gambit	1. e4 c6 2. c4 d5 3. e5
 B10	Caro-Kann Defense: St. Patrick's Attack	1. e4 c6 2. Nc3 d5 3. h3
+B10	Caro-Kann Defense: Toikkanen Gambit	1. e4 c6 2. c4 d5 3. e5
 B10	Caro-Kann Defense: Two Knights Attack	1. e4 c6 2. Nc3 d5 3. Nf3
 B11	Caro-Kann Defense: Two Knights Attack, Mindeno Variation	1. e4 c6 2. Nc3 d5 3. Nf3 Bg4
 B11	Caro-Kann Defense: Two Knights Attack, Mindeno Variation, Exchange Line	1. e4 c6 2. Nc3 d5 3. Nf3 Bg4 4. h3 Bxf3

--- a/b.tsv
+++ b/b.tsv
@@ -286,6 +286,7 @@ B10	Caro-Kann Defense: Scorpion-Horus Gambit	1. e4 c6 2. Nc3 d5 3. d3 dxe4 4. Bg
 B10	Caro-Kann Defense: Spike Variation	1. e4 c6 2. g4
 B10	Caro-Kann Defense: Spike Variation, Scorpion-Grob Gambit	1. e4 c6 2. g4 d5 3. Nc3 dxe4 4. d3
 B10	Caro-Kann Defense: Toikkanen Gambit	1. e4 c6 2. c4 d5 3. e5
+B10	Caro-Kann Defense: St. Patrick's Attack	1. e4 c6 2. Nc3 d5 3. Nf3
 B10	Caro-Kann Defense: Two Knights Attack	1. e4 c6 2. Nc3 d5 3. Nf3
 B11	Caro-Kann Defense: Two Knights Attack, Mindeno Variation	1. e4 c6 2. Nc3 d5 3. Nf3 Bg4
 B11	Caro-Kann Defense: Two Knights Attack, Mindeno Variation, Exchange Line	1. e4 c6 2. Nc3 d5 3. Nf3 Bg4 4. h3 Bxf3

--- a/b.tsv
+++ b/b.tsv
@@ -286,7 +286,7 @@ B10	Caro-Kann Defense: Scorpion-Horus Gambit	1. e4 c6 2. Nc3 d5 3. d3 dxe4 4. Bg
 B10	Caro-Kann Defense: Spike Variation	1. e4 c6 2. g4
 B10	Caro-Kann Defense: Spike Variation, Scorpion-Grob Gambit	1. e4 c6 2. g4 d5 3. Nc3 dxe4 4. d3
 B10	Caro-Kann Defense: Toikkanen Gambit	1. e4 c6 2. c4 d5 3. e5
-B10	Caro-Kann Defense: St. Patrick's Attack	1. e4 c6 2. Nc3 d5 3. Nf3
+B10	Caro-Kann Defense: St. Patrick's Attack	1. e4 c6 2. Nc3 d5 3. h3
 B10	Caro-Kann Defense: Two Knights Attack	1. e4 c6 2. Nc3 d5 3. Nf3
 B11	Caro-Kann Defense: Two Knights Attack, Mindeno Variation	1. e4 c6 2. Nc3 d5 3. Nf3 Bg4
 B11	Caro-Kann Defense: Two Knights Attack, Mindeno Variation, Exchange Line	1. e4 c6 2. Nc3 d5 3. Nf3 Bg4 4. h3 Bxf3


### PR DESCRIPTION
I believe the existing name, "A00 Van Geet Opening: Caro-Kann Variation, St. Patrick's Attack 1. Nc3 d5 2. e4 c6 3. h3," makes no sense, given that the more conventional move order leading to the same position is 1. e4 c6 2. Nc3 d5. Because of that I suggest relocating it to the other Caro-Kann lines and removing the Van Geet Opening prefix.