### PR TITLE
Quade -> Quaade

### DIFF
--- a/c.tsv
+++ b/c.tsv
@@ -469,7 +469,7 @@ C37	King's Gambit Accepted: Muzio Gambit, Holloway Defense	1. e4 e5 2. f4 exf4 3
 C37	King's Gambit Accepted: Muzio Gambit, Kling and Horwitz Counterattack	1. e4 e5 2. f4 exf4 3. Nf3 g5 4. Bc4 g4 5. O-O Qe7
 C37	King's Gambit Accepted: Muzio Gambit, Sarratt Defense	1. e4 e5 2. f4 exf4 3. Nf3 g5 4. Bc4 g4 5. O-O gxf3 6. Qxf3 Qf6
 C37	King's Gambit Accepted: Muzio Gambit, Wild Muzio Gambit	1. e4 e5 2. f4 exf4 3. Nf3 g5 4. Bc4 g4 5. O-O
-C37	King's Gambit Accepted: Quade Gambit	1. e4 e5 2. f4 exf4 3. Nf3 g5 4. Nc3
+C37	King's Gambit Accepted: Quaade Gambit	1. e4 e5 2. f4 exf4 3. Nf3 g5 4. Nc3
 C37	King's Gambit Accepted: Rosentreter Gambit	1. e4 e5 2. f4 exf4 3. Nf3 g5 4. d4
 C37	King's Gambit Accepted: Rosentreter Gambit, Bird Gambit	1. e4 e5 2. f4 exf4 3. Nf3 g5 4. d4 g4 5. Ne5 Qh4+ 6. g3
 C37	King's Gambit Accepted: Rosentreter Gambit, Sörensen Gambit	1. e4 e5 2. f4 exf4 3. Nf3 g5 4. d4 g4 5. Nc3


### PR DESCRIPTION
The Quaade Gambit is named after Captain L. Quaade, who published his ideas in the 'Deutsche Schachzeitung' in 1882 (page 360): 
https://babel.hathitrust.org/cgi/pt?id=njp.32101072325416&seq=374
The name Quaade is also mentioned in 'Deutsche Schachzeitung' in 1884 (page 167):
https://babel.hathitrust.org/cgi/pt?id=njp.32101072325796&seq=181 
Additionally, Wikipedia also spells Quaade with two a's: 
https://en.wikipedia.org/wiki/King%27s_Gambit#4.Nc3:_Quaade_Gambit