### PR TITLE
Alien Gambit

### DIFF
--- a/b.tsv
+++ b/b.tsv
@@ -335,9 +335,9 @@ B14	Caro-Kann Defense: Panov Attack, Main Line	1. e4 c6 2. d4 d5 3. exd5 cxd5 4.
 B15	Caro-Kann Defense	1. e4 c6 2. d4 d5 3. Nc3
 B15	Caro-Kann Defense	1. e4 c6 2. d4 d5 3. Nc3 dxe4
 B15	Caro-Kann Defense: Alekhine Gambit	1. e4 c6 2. d4 d5 3. Nc3 dxe4 4. Nxe4 Nf6 5. Bd3
+B15	Caro-Kann Defense: Alien Gambit	1. e4 c6 2. d4 d5 3. Nc3 dxe4 4. Nxe4 Nf6 5. Ng5 h6 6. Nxf7
 B15	Caro-Kann Defense: Campomanes Attack	1. e4 c6 2. d4 d5 3. Nc3 Nf6
 B15	Caro-Kann Defense: Forgacs Variation	1. e4 c6 2. d4 d5 3. Nc3 dxe4 4. Nxe4 Nf6 5. Nxf6+ exf6 6. Bc4
-B15	Caro-Kann Defense: Alien Gambit 1. e4 c6 2. d4 d5 3. Nc3 dxe4 4. Nxe4 Nf6 5. Ng5 h6 6. Nxf7
 B15	Caro-Kann Defense: Gurgenidze Counterattack	1. e4 c6 2. d4 d5 3. Nc3 b5
 B15	Caro-Kann Defense: Gurgenidze System	1. e4 c6 2. d4 d5 3. Nc3 g6
 B15	Caro-Kann Defense: Main Line	1. e4 c6 2. d4 d5 3. Nd2 dxe4 4. Nxe4

--- a/b.tsv
+++ b/b.tsv
@@ -337,6 +337,7 @@ B15	Caro-Kann Defense	1. e4 c6 2. d4 d5 3. Nc3 dxe4
 B15	Caro-Kann Defense: Alekhine Gambit	1. e4 c6 2. d4 d5 3. Nc3 dxe4 4. Nxe4 Nf6 5. Bd3
 B15	Caro-Kann Defense: Campomanes Attack	1. e4 c6 2. d4 d5 3. Nc3 Nf6
 B15	Caro-Kann Defense: Forgacs Variation	1. e4 c6 2. d4 d5 3. Nc3 dxe4 4. Nxe4 Nf6 5. Nxf6+ exf6 6. Bc4
+B15	Caro-Kann Defense: Alien Gambit 1. e4 c6 2. d4 d5 3. Nc3 dxe4 4. Nxe4 Nf6 5. Ng5 h6 6. Nxf7
 B15	Caro-Kann Defense: Gurgenidze Counterattack	1. e4 c6 2. d4 d5 3. Nc3 b5
 B15	Caro-Kann Defense: Gurgenidze System	1. e4 c6 2. d4 d5 3. Nc3 g6
 B15	Caro-Kann Defense: Main Line	1. e4 c6 2. d4 d5 3. Nd2 dxe4 4. Nxe4


### PR DESCRIPTION
The **Alien Gambit** is a recently popular, albeit speculative, hyper-aggressive knight sacrifice against the Caro-Kann Defense following the moves 1. e4 c6 2. d4 d5 3. Nc3 dxe4 4. Nxe4 Nf6 5. Ng5?! h6 6. Nxf7?!. Although the sacrifice is considered unsound at the highest level, it has been utilizied successfully in bullet and blitz games by Bulgarian content creator and CM Volen Dyulgerov aka Witty Alien, for whom the opening is named for.

All one needs to do is Google "alien gambit", after which you will find an endlessly entertaining slew of sacrificial, romantic games played by the energetic [Dyulgerov ](https://www.youtube.com/shorts/AmtGFX1RvW0)(and [others](https://www.youtube.com/watch?v=S6dozy6euxc&pp=ygUMQWxpZW4gR2FtYml0)) to recognize its legitimacy. The opening is not printed in any book, nor mentioned in any thousand-page opening monograph, but has stirred an avid cult of gambiteers seeking to enjoy open lines, attacking prospects, and Morphy-esque wins. In the words of IM Eric Rosen, "[wow](https://youtu.be/9h8UcYJZz-Q?t=412)."

Recognizing the Alien Gambit in the Lichess database is recognizing over 78,000 games that have already been played. There is nothing to lose. I humbly submit this addition to the ever-so-impressive and wonderful resource that is the Lichess opening database.