### PR TITLE
Add Siberian Variation

### DIFF
--- a/b.tsv
+++ b/b.tsv
@@ -410,6 +410,7 @@ B21	Sicilian Defense: Smith-Morra Gambit Accepted, Morphy Defense Deferred	1. e4
 B21	Sicilian Defense: Smith-Morra Gambit Accepted, Paulsen Formation	1. e4 c5 2. d4 cxd4 3. c3 dxc3 4. Nxc3 Nc6 5. Nf3 e6 6. Bc4 a6
 B21	Sicilian Defense: Smith-Morra Gambit Accepted, Pin Defense	1. e4 c5 2. d4 cxd4 3. c3 dxc3 4. Nxc3 Nc6 5. Nf3 e6 6. Bc4 Bb4
 B21	Sicilian Defense: Smith-Morra Gambit Accepted, Scheveningen Formation	1. e4 c5 2. d4 cxd4 3. c3 dxc3 4. Nxc3 Nc6 5. Nf3 d6 6. Bc4 e6
+B21	Sicilian Defense: Smith-Morra Gambit Accepted, Siberian Variation	1. e4 c5 2. d4 cxd4 3. c3 dxc3 4. Nxc3 Nc6 5. Nf3 e6 6. Bc4 Qc7
 B21	Sicilian Defense: Smith-Morra Gambit Accepted, Sozin Formation	1. e4 c5 2. d4 cxd4 3. c3 dxc3 4. Nxc3 Nc6 5. Bc4 e6 6. Nf3 d6 7. O-O a6 8. Qe2 b5
 B21	Sicilian Defense: Smith-Morra Gambit Accepted, Taimanov Formation	1. e4 c5 2. d4 cxd4 3. c3 dxc3 4. Nxc3 e6 5. Bc4 a6 6. Nf3 Ne7
 B21	Sicilian Defense: Smith-Morra Gambit Declined, Alapin Formation	1. e4 c5 2. d4 cxd4 3. c3 Nf6


### PR DESCRIPTION
### 1. Adding Smith Morra Gambit Accepted

The database later distinguishes between the accepted version and the declined version. But the accepted version already starts with 3.... dxc3.

### 2. Add Siberian Variation

https://en.wikipedia.org/wiki/Smith%E2%80%93Morra_Gambit#Morra_Gambit_Declined

It leads to the famous Siberian Trap:

https://en.wikipedia.org/wiki/Sicilian_Defence,_Smith%E2%80%93Morra_Gambit,_Siberian_Trap

Maybe this variation should be called Siberian Trap?