### PR TITLE
Remove redundant line in Danish Gambit

### DIFF
--- a/c.tsv
+++ b/c.tsv
@@ -213,7 +213,6 @@ C21	Center Game: Halasz-McDonnell Gambit, Crocodile Variation	1. e4 e5 2. d4 exd
 C21	Center Game: Kieseritzky Variation	1. e4 e5 2. d4 exd4 3. Nf3
 C21	Center Game: Kieseritzky Variation	1. e4 e5 2. d4 exd4 3. Nf3 c5
 C21	Center Game: Kieseritzky Variation	1. e4 e5 2. d4 exd4 3. Nf3 c5 4. Bc4
-C21	Center Game: Kieseritzky Variation	1. e4 e5 2. d4 exd4 3. Nf3 c5 4. Bc4 b5
 C21	Center Game: Lanc-Arnold Gambit	1. e4 e5 2. d4 exd4 3. Nf3 Bc5 4. c3
 C21	Center Game: Lanc-Arnold Gambit, Schippler Gambit	1. e4 e5 2. d4 exd4 3. Nf3 Bc5 4. c3 dxc3 5. Bc4
 C21	Center Game: Ross Gambit	1. e4 e5 2. d4 exd4 3. Bd3


### PR DESCRIPTION
### Remove C21	Center Game: Kieseritzky Variation	1. e4 e5 2. d4 exd4 3. Nf3 c5 4. Bc4 b5

I looked at the line with the help of the Lichess Opening Explorer. As you can see after Bc4 only 1% of the games are 4... b5 with 6689 games. After the move b5 Lichess shows a total of 6679 games. I don't know why there are less games with this position than before, but it is safe to say that 4...b5 is not a move where many transpositions occur.

![Screenshot 2024-06-02 124824](https://github.com/lichess-org/chess-openings/assets/134768835/74dd8d94-1975-48b7-85f3-d8db08914722)


![Screenshot 2024-06-02 124753](https://github.com/lichess-org/chess-openings/assets/134768835/df8e1d6b-bc79-444b-8509-5b171792b023)
