### PR TITLE
KID: Fianchetto Variation with Nf3

### DIFF
--- a/e.tsv
+++ b/e.tsv
@@ -207,8 +207,8 @@ E60	Indian Defense: Anti-Grünfeld, Advance Variation	1. d4 Nf6 2. c4 g6 3. d5
 E60	Indian Defense: Anti-Grünfeld, Alekhine Variation	1. d4 Nf6 2. c4 g6 3. f3
 E60	Indian Defense: Anti-Grünfeld, Alekhine Variation, Leko Gambit	1. d4 Nf6 2. c4 g6 3. f3 e5
 E60	Indian Defense: Anti-Grünfeld, Basman-Williams Attack	1. d4 Nf6 2. c4 g6 3. h4
-E60	Indian Defense: King's Indian Variation, Fianchetto Variation	1. d4 Nf6 2. c4 g6 3. g3 Bg7 4. Bg2
 E60	Indian Defense: West Indian Defense	1. d4 Nf6 2. c4 g6
+E60	King's Indian Defense: Fianchetto Variation	1. d4 Nf6 2. c4 g6 3. Nf3 Bg7 4. g3
 E60	King's Indian Defense: Fianchetto Variation, Immediate Fianchetto	1. d4 Nf6 2. c4 g6 3. g3
 E60	King's Indian Defense: Normal Variation, King's Knight Variation	1. d4 Nf6 2. Nf3 g6 3. c4
 E60	King's Indian Defense: Santasiere Variation	1. d4 Nf6 2. c4 g6 3. Nf3 Bg7 4. b4


### PR DESCRIPTION
Hello, I have a suggestion, but I would like to know from you if this is a proper modification.

Currently:

- This is the [KID: Fianchetto Variation, Immediate Fianchetto](https://lichess.org/opening/Kings_Indian_Defense_Fianchetto_Variation_Immediate_Fianchetto/d4_Nf6_c4_g6_g3)
- And this is the [KID: Fianchetto Variation, Delayed Fianchetto](https://lichess.org/opening/Kings_Indian_Defense_Fianchetto_Variation_Delayed_Fianchetto/d4_Nf6_c4_g6_Nc3_Bg7_Nf3_d6_g3)

In my experience, [this opening](https://lichess.org/opening/Kings_Indian_Defense_Normal_Variation_Kings_Knight_Variation/d4_Nf6_c4_g6_Nf3_Bg7_g3), which is the "middle-ground" between the two above, lead to very similar positions to both of them (especially to the Immediate one).

So I believe it should also be called a **"Fianchetto Variation"**. Currently, though, it is called **"Normal Variation, King's Knight, g3"**.

I am attaching a proposal of code change. Please give me your thoughts.

In the code change proposal, I am also fixing what I believe is a mistake. If the **KID: Fianchetto Variation, Immediate Fianchetto** is followed by 3... Bg7 4, Bg2 (which is its main line), it stops being a **KID** and becomes an **Indian Defense**. I strongly believe this is a mistake, taking into account how other positions are named, so I am also attaching a line removal to fix that.