### PR TITLE
Add Caro-Kann Defense: Tartakower Variation, Perlis Line

### DIFF
--- a/b.tsv
+++ b/b.tsv
@@ -344,7 +344,7 @@ B15	Caro-Kann Defense: Gurgenidze System	1. e4 c6 2. d4 d5 3. Nc3 g6
 B15	Caro-Kann Defense: Main Line	1. e4 c6 2. d4 d5 3. Nd2 dxe4 4. Nxe4
 B15	Caro-Kann Defense: Rasa-Studier Gambit	1. e4 c6 2. d4 d5 3. Nc3 dxe4 4. f3
 B15	Caro-Kann Defense: Tartakower Variation	1. e4 c6 2. d4 d5 3. Nc3 dxe4 4. Nxe4 Nf6 5. Nxf6+ exf6
-B15	Caro-Kann Defense: Tartakower Variation, Perlis Line	1. e4 c6 2. d4 d5 3. Nc3 dxe4 4. Nxe4 Nf6 5. Nxf6+ exf6 6. c3 Bd6 7. Bd3 O-O 8. Qc2 Re8+ 9. Ne2 h6
+B15	Caro-Kann Defense: Tartakower Variation, Perlis Line	1. e4 c6 2. d4 d5 3. Nc3 dxe4 4. Nxe4 Nf6 5. Nxf6+ exf6 6. c3 Bd6 7. Bd3 O-O 8. Qc2 h6
 B15	Caro-Kann Defense: von Hennig Gambit	1. e4 c6 2. d4 d5 3. Nc3 dxe4 4. Bc4
 B16	Caro-Kann Defense: Bronstein-Larsen Variation	1. e4 c6 2. d4 d5 3. Nc3 dxe4 4. Nxe4 Nf6 5. Nxf6+ gxf6
 B16	Caro-Kann Defense: Finnish Variation	1. e4 c6 2. d4 d5 3. Nd2 dxe4 4. Nxe4 h6


### PR DESCRIPTION
This PR adds a historical line of the Caro-Kann Defense, Tartakower Variation,
played by Julius Perlis against Duras in San Sebastian 1912.

This is the earliest known elite-level game featuring 9...h6 in this position.
Modern theory usually prefers 9...h5, but 9...h6 is a known historical alternative.

The game is available in major historical databases.
