### PR TITLE
Four Knights Game: Naroditsky Variation

### DIFF
--- a/c.tsv
+++ b/c.tsv
@@ -783,7 +783,7 @@ C47	Four Knights Game: Halloween Gambit, Oldtimer Variation	1. e4 e5 2. Nf3 Nc6 
 C47	Four Knights Game: Halloween Gambit, Plasma Variation	1. e4 e5 2. Nf3 Nc6 3. Nc3 Nf6 4. Nxe5 Nxe5 5. d4 Nc6 6. d5 Ne5 7. f4 Ng6 8. e5 Ng8 9. d6 cxd6 10. exd6 Qf6 11. Nb5 Rb8
 C47	Four Knights Game: Italian Variation	1. e4 e5 2. Nf3 Nc6 3. Bc4 Nf6 4. Nc3
 C47	Four Knights Game: Italian Variation, Noa Gambit	1. e4 e5 2. Nf3 Nc6 3. Bc4 Nf6 4. Nc3 Nxe4 5. Bxf7+
-C47  Four Knights Game: Naroditsky Variation  1. e4 e5 2. Nf3 Nc6 3. Nc3 Nf6 4. Nd5
+C47	Four Knights Game: Naroditsky Variation	1. e4 e5 2. Nf3 Nc6 3. Nc3 Nf6 4. Nd5
 C47	Four Knights Game: Scotch Variation	1. e4 e5 2. Nf3 Nc6 3. Nc3 Nf6 4. d4
 C47	Four Knights Game: Scotch Variation Accepted	1. e4 e5 2. Nf3 Nc6 3. Nc3 Nf6 4. d4 exd4
 C47	Four Knights Game: Scotch Variation Accepted, Main Line	1. e4 e5 2. Nf3 Nc6 3. Nc3 Nf6 4. d4 exd4 5. Nxd4 Bb4 6. Nxc6 bxc6 7. Bd3 d5 8. exd5 O-O 9. O-O


### PR DESCRIPTION
C47	Four Knights Game: Naroditsky Variation	1. e4 e5 2. Nf3 Nc6 3. Nc3 Nf6 4. Nd5

This opening was dedicated to the late GM Daniel Naroditsky, who played it often.

### **Sourcing**:

Here is its chess.com openings page that also includes some analysis on it:
https://www.chess.com/openings/Four-Knights-Game-Naroditsky-Variation
_____
The Wikipedia page of the Four Knights Game mentions the line:
https://en.wikipedia.org/wiki/Four_Knights_Game#:~:text=4%2ENd5%20is%20the%20Naroditsky%20variation%2E%5B11%5D%20It%20has%20a%20similar%20idea%20to%20the%20Belgrade%20Gambit