### PR TITLE
McDonnell Attack, Toilet Variation

### DIFF
--- a/b.tsv
+++ b/b.tsv
@@ -396,6 +396,7 @@ B21	Sicilian Defense: Coles Sicilian Gambit	1. e4 c5 2. d4 cxd4 3. Qxd4 Nc6 4. Q
 B21	Sicilian Defense: Halasz Gambit	1. e4 c5 2. d4 cxd4 3. f4
 B21	Sicilian Defense: McDonnell Attack	1. e4 c5 2. f4
 B21	Sicilian Defense: McDonnell Attack, Tal Gambit	1. e4 c5 2. f4 d5 3. exd5 Nf6
+B21	Sicilian Defense: McDonnell Attack, Toilet Variation	1. e4 c5 2. f4 d5 3. Nc3
 B21	Sicilian Defense: Morphy Gambit	1. e4 c5 2. d4 cxd4 3. Nf3
 B21	Sicilian Defense: Morphy Gambit, Andreaschek Gambit	1. e4 c5 2. d4 cxd4 3. Nf3 e5 4. c3
 B21	Sicilian Defense: Smith-Morra Gambit	1. e4 c5 2. d4


### PR DESCRIPTION
B21	Sicilian Defense: McDonnell Attack, Toilet Variation	1. e4 c5 2. f4 d5 3. Nc3

One of the silliest opening names ever!

Sourcing:

The wikipedia page on the Sicilian Defense mentions it, and includes a source from Nigel Davies's 'Chess Player's Battle Manual' (1998) https://en.wikipedia.org/wiki/Sicilian_Defence#:~:text=White%20may%20decline%20the%20gambit%20with%203%2ENc3%2C%20called%20the%20%22Toilet%20Variation%22%2C%20so%20named%20after%20its%20reputed%20place%20of%20invention%2E%5B44%5D

Here is Magnus Carlsen being tested on his knowledge of this variation: https://youtu.be/Ac_UkYZUX2E?si=a3JOkx639zxA78xv&t=125

There are many online articles and youtube videos that mention it, here are a couple videos: https://youtu.be/m-eIKix0d6o?si=8wPDjnZGLmmfbDDe
https://youtu.be/64klepF1u_A?si=vvJrp9bOWDh4AliX

This variation is not yet included in the Chess.com opening explorer.