### PR TITLE
Albin Countergambit, Spassky Variation

### DIFF
--- a/d.tsv
+++ b/d.tsv
@@ -142,6 +142,7 @@ D08	Queen's Gambit Declined: Albin Countergambit, Krenosz Variation	1. d4 d5 2. 
 D08	Queen's Gambit Declined: Albin Countergambit, Lasker Trap	1. d4 d5 2. c4 e5 3. dxe5 d4 4. e3 Bb4+ 5. Bd2 dxe3
 D08	Queen's Gambit Declined: Albin Countergambit, Modern Line	1. d4 d5 2. c4 e5 3. dxe5 d4 4. Nf3 Nc6 5. Nbd2
 D08	Queen's Gambit Declined: Albin Countergambit, Normal Line	1. d4 d5 2. c4 e5 3. dxe5 d4 4. Nf3
+D08	Queen's Gambit Declined: Albin Countergambit, Spassky Variation	1. d4 d5 2. c4 e5 3. dxe5 d4 4. e4
 D08	Queen's Gambit Declined: Albin Countergambit, Tartakower Defense	1. d4 d5 2. c4 e5 3. dxe5 d4 4. Nf3 c5
 D09	Queen's Gambit Declined: Albin Countergambit, Fianchetto Variation	1. d4 d5 2. c4 e5 3. dxe5 d4 4. Nf3 Nc6 5. g3
 D09	Queen's Gambit Declined: Albin Countergambit, Fianchetto Variation, Be6 Line	1. d4 d5 2. c4 e5 3. dxe5 d4 4. Nf3 Nc6 5. g3 Be6


### PR DESCRIPTION
D08	Queen's Gambit Declined: Albin Countergambit, Spassky Variation	1. d4 d5 2. c4 e5 3. dxe5 d4 4. e4

### **Sourcing**:

The wikipedia article on the Albin Countergambit mentions this variation, and as it source gives a 1998 edition of 'Encyclopaedia of Chess Openings': https://en.wikipedia.org/wiki/Albin_Countergambit#cite_note-3:~:text=play%2E-,Spassky,3%5D

I did not verify wikipedia's source in Encyclopaedia of Chess Openings, however I did find the game where Spassky played it: https://www.chessgames.com/perl/chessgame?gid=1096746
_____
This dvd course by IM Andrew Martin mentions the variation by name: https://thechessworld.com/store/product/albin-counter-gambit-im-andrew-martin/#:~:text=Part%205%3A%20Spassky%20Variation%204%2Ee4
_____
Chess.com does not have this variation in their opening explorer.