### PR TITLE
Delayed Alapin Variation, with e6, Beaver Gambit

### DIFF
--- a/b.tsv
+++ b/b.tsv
@@ -549,6 +549,7 @@ B38	Sicilian Defense: Accelerated Dragon, Maróczy Bind	1. e4 c5 2. Nf3 Nc6 3. d
 B39	Sicilian Defense: Accelerated Dragon, Maróczy Bind, Breyer Variation	1. e4 c5 2. Nf3 Nc6 3. d4 cxd4 4. Nxd4 g6 5. c4 Bg7 6. Be3 Nf6 7. Nc3 Ng4
 B40	Sicilian Defense: Alapin Variation, Sherzer Variation	1. e4 c5 2. Nf3 e6 3. c3 Nf6 4. e5 Nd5 5. d4 Nc6
 B40	Sicilian Defense: Delayed Alapin Variation, with e6	1. e4 c5 2. Nf3 e6 3. c3
+B40	Sicilian Defense: Delayed Alapin Variation, with e6, Beaver Gambit	1. e4 c5 2. Nf3 e6 3. c3 Nf6 4. e5 Nd5 5. b4
 B40	Sicilian Defense: Drazic Variation	1. e4 c5 2. Nf3 e6 3. d4 a6
 B40	Sicilian Defense: French Variation	1. e4 c5 2. Nf3 e6
 B40	Sicilian Defense: French Variation, Normal	1. e4 c5 2. Nf3 e6 3. d4 cxd4 4. Nxd4 Nf6


### PR DESCRIPTION
B40	Sicilian Defense: Delayed Alapin Variation, with e6, Beaver Gambit	1. e4 c5 2. Nf3 e6 3. c3 Nf6 4. e5 Nd5 5. b4

A wild and aggressive gambit invented by Jonathan Schrantz

### **Sourcing**:

This is a playlist created by Jonathan Schrantz featuring six of his videos on the gambit: https://www.youtube.com/playlist?list=PLY-D5XLgU_kU6F8TGL86FWclhczFM_OFu
_____
A video by 'The Chess Giant' on the line: https://www.youtube.com/watch?v=lQ0RPFR5dnA
Another video from 'The Chess Giant' mentioning the line: https://youtu.be/Hshc99tgHw4?si=-y5lAkl8shIw6Jzq&t=627
_____
A livestream clip of GM Nyzhnyk playing the Beaver Gambit:  https://www.youtube.com/watch?v=RFSdlK0Lzwk
_____
Chess.com does not yet have this line in their opening explorer.