### PR TITLE
French Defense: Rubinstein Variation, Rozman Variation

### DIFF
--- a/c.tsv
+++ b/c.tsv
@@ -103,6 +103,7 @@ C10	French Defense: Rubinstein Variation, Ellis Gambit	1. e4 e6 2. d4 d5 3. Nc3 
 C10	French Defense: Rubinstein Variation, Fort Knox Variation	1. e4 e6 2. d4 d5 3. Nc3 dxe4 4. Nxe4 Bd7 5. Nf3 Bc6
 C10	French Defense: Rubinstein Variation, Kasparov Attack	1. e4 e6 2. d4 d5 3. Nd2 dxe4 4. Nxe4 Nd7 5. Nf3 Ngf6 6. Nxf6+ Nxf6 7. c3
 C10	French Defense: Rubinstein Variation, Maric Variation	1. e4 e6 2. d4 d5 3. Nc3 dxe4 4. Nxe4 Qd5
+C10	French Defense: Rubinstein Variation, Rozman Variation	1. e4 e6 2. d4 d5 3. Nc3 dxe4 4. Nxe4 Nf6 5. Nxf6+ gxf6
 C11	French Defense: Classical Variation	1. e4 e6 2. d4 d5 3. Nc3 Nf6
 C11	French Defense: Classical Variation	1. e4 e6 2. d4 d5 3. Nc3 Nf6 4. Bg5
 C11	French Defense: Classical Variation, Burn Variation	1. e4 e6 2. d4 d5 3. Nc3 Nf6 4. Bg5 dxe4


### PR DESCRIPTION
C10	French Defense: Rubinstein Variation, Rozman Variation	1. e4 e6 2. d4 d5 3. Nc3 dxe4 4. Nxe4 Nf6 5. Nxf6+ gxf6

A variation of the rubinstein french invented by IM Levy Rozman, in a youtube video.

----------Sourcing:

Unfortunately, Rozman's youtube video was the only source I could find. However, it has 416k views and this line has not been named yet so I figured i'd bring it up: https://www.youtube.com/watch?v=vLH1Yw6skaI
_____
Chess.com does not have this line in their opening explorer.