### PR TITLE
Sicilian Defense: Closed, Carlsen Variation

### DIFF
--- a/b.tsv
+++ b/b.tsv
@@ -438,6 +438,7 @@ B22	Sicilian Defense: Heidenfeld Variation	1. e4 c5 2. c3 Nf6 3. e5 Nd5 4. Nf3 N
 B23	Sicilian Defense: Closed	1. e4 c5 2. Nc3
 B23	Sicilian Defense: Closed	1. e4 c5 2. Nc3 e6
 B23	Sicilian Defense: Closed	1. e4 c5 2. Nc3 e6 3. g3
+B23	Sicilian Defense: Closed, Carlsen Variation	1. e4 c5 2. Nc3 d6 3. d4 cxd4 4. Qxd4 Nc6 5. Qd2
 B23	Sicilian Defense: Closed, Chameleon Variation	1. e4 c5 2. Nc3 Nc6 3. Nge2
 B23	Sicilian Defense: Closed, Grob Attack	1. e4 c5 2. Nc3 Nc6 3. g4
 B23	Sicilian Defense: Closed, Korchnoi Defense	1. e4 c5 2. Nc3 e6 3. g3 d5


### PR DESCRIPTION
B23	Sicilian Defense: Closed, Carlsen Variation	1. e4 c5 2. Nc3 d6 3. d4 cxd4 4. Qxd4 Nc6 5. Qd2

### **Sourcing**:

'The Carlsen Variation' by FIDE Master Carsten Hansen: https://www.amazon.com/gp/product/B08D3X8J46?ref_=dbs_m_mng_rwt_calw_tkin_0&storeType=ebooks
_____
A chess.com article on 'The Carlsen Variation': https://www.chess.com/blog/2Bf41-0/the-carlsen-variation-of-the-sicilian
_____
Chess.com simply calls the shorter line 1. e4 c5 2. Nc3 d6 3.d4 the 'Magnus Sicilian'. https://www.chess.com/openings/Magnus-Sicilian However, Hansen's book calls it the 'Carlsen Variation' and not 'Magnus Sicilian' so I kept the name at that. I also extended the move order to 5. Qd2 instead of just 3. d4, since the book only introduces the variation after 5.Qd2, and also after 3.d4 white can still transpose into other openings with 5.Bb5, for example. Additionally, both of Magnus's games after 3.d4 feature 5. Qd2
_____
Here are the two games Magnus played in this line: 
https://lichess.org/xUg9YNKP
https://lichess.org/34HWNrUa
_____
A gothamchess clip, calling it 'The Magnus Sicilian': https://www.youtube.com/watch?v=tQVbx9anpZU