### PR TITLE
Sicilian Defense: Alapin Variation, Anti-Alapin Gambit

### DIFF
--- a/b.tsv
+++ b/b.tsv
@@ -425,6 +425,7 @@ B21	Sicilian Defense: Smith-Morra Gambit Declined, Push Variation	1. e4 c5 2. d4
 B21	Sicilian Defense: Smith-Morra Gambit Declined, Scandinavian Formation	1. e4 c5 2. d4 cxd4 3. c3 d5
 B21	Sicilian Defense: Smith-Morra Gambit Declined, Wing Formation	1. e4 c5 2. d4 cxd4 3. c3 Qa5
 B22	Sicilian Defense: Alapin Variation	1. e4 c5 2. c3
+B22	Sicilian Defense: Alapin Variation, Anti-Alapin Gambit	1. e4 c5 2. c3 d5 3. exd5 Nf6
 B22	Sicilian Defense: Alapin Variation, Barmen Defense	1. e4 c5 2. c3 d5 3. exd5 Qxd5
 B22	Sicilian Defense: Alapin Variation, Barmen Defense, Central Exchange	1. e4 c5 2. c3 d5 3. exd5 Qxd5 4. d4 cxd4 5. cxd4 Nc6 6. Nf3 Bg4
 B22	Sicilian Defense: Alapin Variation, Barmen Defense, Endgame Variation	1. e4 c5 2. c3 d5 3. exd5 Qxd5 4. d4 cxd4 5. cxd4 Nc6 6. Nf3 Bg4 7. Nc3 Bxf3 8. gxf3 Qxd4 9. Qxd4 Nxd4


### PR DESCRIPTION
B22	Sicilian Defense: Alapin Variation, Anti-Alapin Gambit	1. e4 c5 2. c3 d5 3. exd5 Nf6

### **Sourcing**:

A book cowritten by FIDE master Carsten Hansen and IM Cyrus Lakdawala:
https://www.amazon.com/gp/product/B0BLHLDPQ8?ref_=dbs_m_mng_rwt_calw_tkin_6&storeType=ebooks
_____
Chess.com does not yet have a name for this line in their opening explorer.