### PR TITLE
Réti Opening: Advance Variation, Navara Gambit

### DIFF
--- a/a.tsv
+++ b/a.tsv
@@ -269,6 +269,7 @@ A08	Zukertort Opening: Reversed Grünfeld	1. Nf3 d5 2. g3 c5 3. Bg2 Nc6 4. d4 e6
 A09	Réti Opening	1. Nf3 d5 2. c4
 A09	Réti Opening: Advance Variation	1. Nf3 d5 2. c4 d4
 A09	Réti Opening: Advance Variation, Michel Gambit	1. Nf3 d5 2. c4 d4 3. b4 c5
+A09	Réti Opening: Advance Variation, Navara Gambit	1. Nf3 d5 2. c4 d4 3. b4 g5
 A09	Réti Opening: Penguin Variation	1. Nf3 d5 2. c4 d4 3. Rg1
 A09	Réti Opening: Reversed Blumenfeld Gambit	1. Nf3 d5 2. c4 d4 3. e3 c5 4. b4
 A09	Réti Opening: Réti Accepted	1. Nf3 d5 2. c4 dxc4


### PR DESCRIPTION
A09	Réti Opening: Advance Variation, Navara Gambit	1. Nf3 d5 2. c4 d4 3. b4 g5

### **Sourcing**:

A book by FIDE Master Carsten Hansen on the Navara Gambit: https://www.amazon.com/gp/product/B0DRSXNRMV?ref_=dbs_m_mng_rwt_calw_tkin_10&storeType=ebooks
_____
A youtube video (21k views) by IM Perunovic also calling it the Navara Gambit: https://www.youtube.com/watch?v=7vvw7ImegGA
_____
This video (1.1k views) also calls it the Navara Gambit: https://www.youtube.com/watch?v=DhNI67OnaWE
_____
Chess.com does not have this line in their opening explorer yet.