### PR TITLE
Sicilian Dragon, Yugoslav Attack, Chinese Dragon

### DIFF
--- a/b.tsv
+++ b/b.tsv
@@ -687,6 +687,7 @@ B77	Sicilian Defense: Dragon Variation, Yugoslav Attack, Czerniak Variation	1. e
 B77	Sicilian Defense: Dragon Variation, Yugoslav Attack, Main Line	1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 g6 6. Be3 Bg7 7. f3 O-O 8. Qd2 Nc6 9. Bc4
 B77	Sicilian Defense: Dragon Variation, Yugoslav Attack, Sosonko Variation	1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 g6 6. Be3 Bg7 7. f3 Nc6 8. Qd2 O-O 9. Bc4 Nd7
 B78	Sicilian Defense: Dragon Variation, Yugoslav Attack	1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 g6 6. Be3 Bg7 7. f3 O-O 8. Qd2 Nc6 9. Bc4 Bd7 10. O-O-O
+B78	Sicilian Defense: Dragon Variation, Yugoslav Attack, Chinese Dragon	1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 g6 6. Be3 Bg7 7. f3 O-O 8. Qd2 Nc6 9. Bc4 Bd7 10. O-O-O Rb8
 B78	Sicilian Defense: Dragon Variation, Yugoslav Attack, Old Line	1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 g6 6. Be3 Bg7 7. f3 O-O 8. Qd2 Nc6 9. Bc4 Bd7 10. O-O-O Rc8
 B79	Sicilian Defense: Dragon Variation, Yugoslav Attack	1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 g6 6. Be3 Bg7 7. f3 O-O 8. Qd2 Nc6 9. Bc4 Bd7 10. h4 Qa5 11. O-O-O Rfc8 12. Bb3
 B79	Sicilian Defense: Dragon Variation, Yugoslav Attack, Soltis Variation	1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 g6 6. Be3 Bg7 7. f3 O-O 8. Qd2 Nc6 9. Bc4 Bd7 10. O-O-O Qa5 11. h4 Rfc8 12. Bb3 h5


### PR DESCRIPTION
B78	Sicilian Defense: Dragon Variation, Yugoslav Attack, Chinese Dragon	1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 g6 6. Be3 Bg7 7. f3 O-O 8. Qd2 Nc6 9. Bc4 Bd7 10. O-O-O Rb8

### **Sourcing**:

The Wikipedia article on the Sicilian Dragon mentions the Chinese Dragon line: https://en.wikipedia.org/wiki/Sicilian_Defence%2C_Dragon_Variation#:~:text=Nc4%2E-,More,Dragon
_____
A chess.com article refers to this line as the Chinese Dragon (2015): https://www.chess.com/article/view/how-to-play-the-chinese-dragon

^The chess.com article claims:
"Although the move 10...Rb8 was used several times in the 20th century, it was amazingly unknown until in 2002, when the Belgian master Luc Henris wrote an article about the variation for New in Chess. In this article, he christened the variation the "Chinese Dragon," since he was living in China when he began to analyze the move."

Although I wasn't able to find a copy of the 2002 New in Chess Article, I did find FIDE Master Luc Henris's 9 page analysis of the Chinese Dragon Variation in the 2002 New in Chess Yearbook 62 (Screenshot of the cover has been included).
_____
This video by IM Perunovic is titled "A Textbook Chinese Dragon Attack! From Chessable Prep to Checkmate!":  https://www.youtube.com/watch?v=Mw8RUh6wMuM

Another video by IM Peronovic covers this variation: https://www.youtube.com/watch?v=pDOfxisn8mg
_____
"The Hungarian Dragon" by IM Junior Tay (2022) mentions the Chinese Dragon by name on pages 14 and 128:
https://www.amazon.com/Hungarian-Dragon-creative-resourceful-dangerous/dp/879381268X
_____
In 2012 a book written by Raymond Pearson was titled "The Chinese Dragon": https://www.waterstones.com/book/the-chinese-dragon/raymond-pearson/9781780882185 Pearson's books seems to be unavailable from popular online retailers but he has a website dedicated to its sale: https://sites.google.com/site/sicilianchinesedragon/
_____
US Senior Champion Joel Johnston's book "Attacking 101: Volume #002" (2015) features the Chinese Dragon in pages 122-125: https://www.amazon.com/Attacking-101-002-Joel-Johnson/dp/1329600533
_____
"Grandmaster Repertoire - The Dragon Volume 1" (2015) by GM Gawain Jones mentions the Chinese dragon on pages 10, 249, and 265: https://www.amazon.com/Dragon-Grandmaster-Repertoire-Gawain-Jones/dp/1784830070
_____
GM Simon William's video course "Killer Dragon" chapters 14-18 cover the Chinese Dragon: https://gingergm.com/library/killer-dragon
_____
Chess.com does not yet have the Chinese Dragon in their opening explorer.
_____
Cover of New in Chess Yearbook 62 (2002):
<img width="774" height="1133" alt="Screenshot 2026-01-20 192510" src="https://github.com/user-attachments/assets/b2c54894-6f5f-4f08-b85e-3a008a23bb6f" />
