### PR TITLE
Added the Carlsen Variation of the QGD

### DIFF
--- a/d.tsv
+++ b/d.tsv
@@ -311,6 +311,7 @@ D34	Tarrasch Defense: Classical Variation, Réti Variation	1. d4 d5 2. c4 e6 3. 
 D34	Tarrasch Defense: Classical Variation, Spassky Variation	1. d4 d5 2. c4 e6 3. Nc3 c5 4. cxd5 exd5 5. Nf3 Nc6 6. g3 Nf6 7. Bg2 Be7 8. O-O O-O 9. Bg5 cxd4 10. Nxd4 h6 11. Be3 Bg4
 D34	Tarrasch Defense: Prague Variation, Main Line	1. d4 d5 2. c4 e6 3. Nc3 c5 4. cxd5 exd5 5. Nf3 Nc6 6. g3 Nf6 7. Bg2 Be7
 D35	Queen's Gambit Declined: Exchange Variation	1. d4 Nf6 2. c4 e6 3. Nc3 d5 4. cxd5
+D35	Queen's Gambit Declined: Exchange Variation, Carlsen Variation	1. d4 Nf6 2. c4 e6 3. Nc3 d5 4. cxd5 exd5 5. Bg5 Be7 6. e3 h6 7. Bh4 Bg4
 D35	Queen's Gambit Declined: Exchange Variation, Chameleon Variation	1. d4 Nf6 2. c4 e6 3. Nc3 d5 4. cxd5 exd5 5. Bg5 Be7 6. e3 O-O 7. Bd3 Nbd7 8. Qc2 Re8 9. Nge2 Nf8 10. O-O-O
 D35	Queen's Gambit Declined: Exchange Variation, Positional Variation	1. d4 Nf6 2. c4 e6 3. Nc3 d5 4. cxd5 exd5 5. Bg5
 D35	Queen's Gambit Declined: Exchange Variation, Positional Variation	1. d4 Nf6 2. c4 e6 3. Nc3 d5 4. cxd5 exd5 5. Bg5 c6


### PR DESCRIPTION
I added a variation of the QGD Exchange Variation popularized by Magnus Carlsen, it's called the Carlsen Variation by GM Illingworth (https://www.chess.com/blog/Illingworth/the-carlsen-variation-of-the-exchange-qgd)  and GM Davies https://www.chesspublishing.com/content/7/index.htm
Also the first major game to be played in this line was by Carlsen as black (Maghsoodloo vs Carlsen 2023)  https://www.chessgames.com/perl/chessgame?gid=2457693