### PR TITLE
Hyperaccelerated Fianchetto -> Hyperaccelerated Dragon

### DIFF
--- a/b.tsv
+++ b/b.tsv
@@ -473,7 +473,7 @@ B27	Sicilian Defense: Bücker Variation	1. e4 c5 2. Nf3 h6
 B27	Sicilian Defense: Double-Dutch Gambit	1. e4 c5 2. Nf3 f5 3. exf5 Nh6
 B27	Sicilian Defense: Frederico Variation	1. e4 c5 2. Nf3 g6 3. d4 f5
 B27	Sicilian Defense: Hyperaccelerated Dragon	1. e4 c5 2. Nf3 g6
-B27	Sicilian Defense: Hyperaccelerated Fianchetto	1. e4 c5 2. Nf3 g6 3. d4
+B27	Sicilian Defense: Hyperaccelerated Dragon	1. e4 c5 2. Nf3 g6 3. d4
 B27	Sicilian Defense: Hyperaccelerated Pterodactyl	1. e4 c5 2. Nf3 g6 3. d4 Bg7
 B27	Sicilian Defense: Hyperaccelerated Pterodactyl, Exchange Variation	1. e4 c5 2. Nf3 g6 3. d4 Bg7 4. dxc5 Qa5+ 5. Nc3 Bxc3+ 6. bxc3 Qxc3+
 B27	Sicilian Defense: Jalalabad Variation	1. e4 c5 2. Nf3 e5


### PR DESCRIPTION
I believe hyperaccelerated dragon and hyperaccelerated fianchetto refer to the same variation, so this is a naming inconsistency. As you can see from these two lines currently in the database, the naming changes depending on if white plays 3.d4:

B27	Sicilian Defense: Hyperaccelerated Dragon	1. e4 c5 2. Nf3 g6
B27	Sicilian Defense: Hyperaccelerated Fianchetto 1. e4 c5 2. Nf3 g6 3. d4