### PR TITLE
Added A45 line

### DIFF
--- a/a.tsv
+++ b/a.tsv
@@ -558,6 +558,7 @@ A45	Amazon Attack: Siberian Attack	1. d4 Nf6 2. Nc3 d5 3. Qd3
 A45	Canard Opening	1. d4 Nf6 2. f4
 A45	Indian Defense	1. d4 Nf6
 A45	Indian Defense: Accelerated London System	1. d4 Nf6 2. Bf4
+A45 Indian Defense: Accelerated London System, Skala Gambit 1. d4 Nf6 2. Bf4 c5 3. e3 Nd5 4. Bg3 Qb6 5. b3 cxd4 6. exd4 e5
 A45	Indian Defense: Gedult Attack	1. d4 Nf6 2. f3 d5 3. g4
 A45	Indian Defense: Gibbins-Weidenhagen Gambit	1. d4 Nf6 2. g4
 A45	Indian Defense: Gibbins-Weidenhagen Gambit Accepted	1. d4 Nf6 2. g4 Nxg4


### PR DESCRIPTION
Added the line:

A45 Indian Defense: Accelerated London System, Skala Gambit 1. d4 Nf6 2. Bf4 c5 3. e3 Nd5 4. Bg3 Qb6 5. b3 cxd4 6. exd4 e5

Which Eric Rosen (known for playing the London System) referred to as the "Skala Gambit" at the start of a livestream on 17.02.2026, around 16:45.

Unfortunately, I can't find any online resources on this name. Eric might have it from some London book.
