### PR TITLE
Added a new C47 and B10 line

### DIFF
--- a/b.tsv
+++ b/b.tsv
@@ -273,6 +273,7 @@ B10	Caro-Kann Defense: Accelerated Panov Attack, Van Weersel Attack	1. e4 c6 2. 
 B10	Caro-Kann Defense: Apocalypse Attack	1. e4 c6 2. Nf3 d5 3. exd5 cxd5 4. Ne5
 B10	Caro-Kann Defense: Breyer Variation	1. e4 c6 2. d3
 B10	Caro-Kann Defense: Breyer Variation, Stein Attack	1. e4 c6 2. d3 d5 3. Nd2 g6 4. Ngf3 Bg7 5. g3 e5 6. Bg2 Ne7 7. O-O O-O 8. b4
+B10	Caro-Kann Defense: Dinic Gambit	1. e4 c6 2. Nf3 d5 3. d3 dxe4 4. Ng5
 B10	Caro-Kann Defense: Endgame Offer	1. e4 c6 2. Nf3 d5 3. d3
 B10	Caro-Kann Defense: Endgame Variation	1. e4 c6 2. Nf3 d5 3. d3 dxe4 4. dxe4 Qxd1+ 5. Kxd1
 B10	Caro-Kann Defense: Euwe Attack	1. e4 c6 2. b3

--- a/c.tsv
+++ b/c.tsv
@@ -775,6 +775,7 @@ C46	Three Knights Opening: Steinitz Defense	1. e4 e5 2. Nf3 Nc6 3. Nc3 g6
 C46	Three Knights Opening: Steinitz-Rosenthal Variation	1. e4 e5 2. Nf3 Nc6 3. Nc3 g6 4. d4 exd4 5. Nd5
 C46	Three Knights Opening: Winawer Defense	1. e4 e5 2. Nf3 Nc6 3. Nc3 f5
 C47	Four Knights Game	1. e4 e5 2. Nf3 Nc6 3. Nc3 Nf6
+C47	Four Knights Game: Giri Variation	1. e4 e5 2. Nf3 Nc6 3. Nc3 Nf6 4. h3
 C47	Four Knights Game: Glek System	1. e4 e5 2. Nf3 Nc6 3. Nc3 Nf6 4. g3
 C47	Four Knights Game: Glek System	1. e4 e5 2. Nf3 Nc6 3. Nc3 Nf6 4. g3 d5 5. exd5 Nxd5 6. Bg2 Nxc3 7. bxc3
 C47	Four Knights Game: Gunsberg Variation	1. e4 e5 2. Nf3 Nc6 3. Nc3 Nf6 4. a3


### PR DESCRIPTION
I added a trendy line in the 4 knights (4. h3 ECO C47) that seems to have been first popularized by Anish Giri https://www.chessgames.com/perl/chess.pl?pid=107252&playercomp=white&eco=C46, he had 3 games in 2014 scoring 2.5/3 with this variation and I think this is when the variation took off. Also IM Miodrag Perunovic acknowledges this idea started getting popularity with Giri as shown in thie [video](https://www.youtube.com/watch?v=Z4Dmfsw7cfA).

I also added a gambit line in  ECO B10 popularized by FM Dinic, this is one of the most notable games in this line [https://www.chessgames.com/perl/chessgame?gid=2363206] [https://www.chessgames.com/perl/chessgame?gid=2363206]. He has 5 games in this line, probably the most by a high level player in classical chess, and many other sources like [here](https://www.chessable.com/discussion/thread/1005596/) also acknowledge this name. 