### PR TITLE
Add missing Nimzo-Indian named variations (E34, E40, E48)

### DIFF
--- a/e.tsv
+++ b/e.tsv
@@ -121,7 +121,7 @@ E23	Nimzo-Indian Defense: Spielmann Variation, Romanovsky Gambit	1. d4 Nf6 2. c4
 E23	Nimzo-Indian Defense: Spielmann Variation, Stahlberg Variation	1. d4 Nf6 2. c4 e6 3. Nc3 Bb4 4. Qb3 c5 5. dxc5 Nc6 6. Nf3 Ne4 7. Bd2 Nxc5
 E23	Nimzo-Indian Defense: Spielmann Variation, Stahlberg Variation	1. d4 Nf6 2. c4 e6 3. Nc3 Bb4 4. Qb3 c5 5. dxc5 Nc6 6. Nf3 Ne4 7. Bd2 Nxc5 8. Qc2 f5 9. g3
 E24	Nimzo-Indian Defense: Sämisch Variation	1. d4 Nf6 2. c4 e6 3. Nc3 Bb4 4. a3
-E24	Nimzo-Indian Defense: Sämisch Variation,  Variation	1. d4 Nf6 2. c4 e6 3. Nc3 Bb4 4. f3 d5 5. a3 Bxc3+ 6. bxc3 c5 7. e3 O-O 8. cxd5 Nxd5
+E24	Nimzo-Indian Defense: Sämisch Variation, Botvinnik Variation	1. d4 Nf6 2. c4 e6 3. Nc3 Bb4 4. f3 d5 5. a3 Bxc3+ 6. bxc3 c5 7. e3 O-O 8. cxd5 Nxd5
 E25	Nimzo-Indian Defense: Sämisch Variation	1. d4 Nf6 2. c4 e6 3. Nc3 Bb4 4. f3 d5 5. a3 Bxc3+ 6. bxc3 c5 7. cxd5
 E25	Nimzo-Indian Defense: Sämisch Variation, Keres Variation	1. d4 Nf6 2. c4 e6 3. Nc3 Bb4 4. f3 d5 5. a3 Bxc3+ 6. bxc3 c5 7. cxd5 Nxd5 8. dxc5
 E25	Nimzo-Indian Defense: Sämisch Variation, Romanovsky Variation	1. d4 Nf6 2. c4 e6 3. Nc3 Bb4 4. f3 d5 5. a3 Bxc3+ 6. bxc3 c5 7. cxd5 Nxd5 8. dxc5 f5


### PR DESCRIPTION
Three named Nimzo-Indian variations that appear in chess literature and multiple opening databases but are currently missing from this repo:
 
1. **E34 Romanishin System (4.Qc2 d5 5.cxd5 Qxd5)**
Named after GM Oleg Romanishin, who revived Alekhine's 5...Qxd5 with the novelty 6...Qf5 in his game against Beliavsky at Groningen 1993. After 6.Nf3 Qf5 7.Qxf5 exf5, Black strengthens the grip on e4. The line is critical for the viability of the entire 4.Qc2 Nimzo-Indian.
Sources:
- [Wikipedia: Nimzo-Indian Defence](https://en.wikipedia.org/wiki/Nimzo-Indian_Defence) - "5...Qxd5 is the Romanishin System named after Oleg Romanishin"
- [Chess.com: From Opening to Endgame - The Nimzo-Indian](https://www.chess.com/article/view/from-opening-to-endgame-the-nimzo-indian) (GM Bryan Smith) - covers the Romanishin System endgame after 6...Qf5
- [Modern Chess: Top-Level Repertoire against the Nimzo-Indian, Part 2](https://www.modern-chess.com/top-level-repertoire-against-the-nimzo-indian-defence-part-2-3h-and-28min-running-time-451) (GM Basso, 2023) - "This creative approach was first used by Oleg Romanishin in 1991"
- Also in: ChessTempo, SCID, Arena opening databases
 
2. **E40 Botvinnik Variation (4.e3 d5 5.a3)**
Named after World Champion Mikhail Botvinnik. White forces Black to either retreat the bishop (5...Be7) or capture on c3, transposing to a Sämisch-type structure considered good for White. Distinct from the existing E24 Sämisch Botvinnik Variation (4.f3 d5 5.a3) and E49 Botvinnik System (4.e3 O-O 5.Bd3 d5 6.a3). Same player, but different move orders in different systems.
Sources:
- [Wikipedia: Nimzo-Indian Defence](https://en.wikipedia.org/wiki/Nimzo-Indian_Defence) - "4...d5 5.a3 leads to the Botvinnik Variation, named after World Champion Mikhail Botvinnik"
- Also in: Chess.com, SCID, Arena opening databases
 
3. **E48 Modern Variation (4.e3 O-O 5.Bd3 d5 6.Ne2)**
Named by FM Carsten Hansen in *The Nimzo-Indian: 4 e3* (Gambit Publications, 2002, ISBN 1-901983-58-7, 320 pages). Covers both 6.Ne2 and the closely related 6.cxd5 exd5 7.Ne2.
Sources:
- Hansen, Carsten (2002). *The Nimzo-Indian: 4 e3*. Gambit Publications. ISBN 1-901983-58-7.
- [Wikipedia: Nimzo-Indian Defence](https://en.wikipedia.org/wiki/Nimzo-Indian_Defence) - "collectively dubbed the Modern Variation by FM Carsten Hansen"
- Also in: Chess.com, SCID, Arena opening databases