### PR TITLE
Added E57, E88, E81 and E71 lines

### DIFF
--- a/e.tsv
+++ b/e.tsv
@@ -250,7 +250,7 @@ E70	King's Indian Defense: Accelerated Averbakh Variation	1. d4 Nf6 2. c4 g6 3. 
 E70	King's Indian Defense: Kramer Variation	1. d4 Nf6 2. c4 g6 3. Nc3 Bg7 4. e4 d6 5. Nge2
 E70	King's Indian Defense: Normal Variation	1. d4 Nf6 2. c4 g6 3. Nc3 Bg7 4. e4
 E70	King's Indian Defense: Normal Variation	1. d4 Nf6 2. c4 g6 3. Nc3 Bg7 4. e4 d6
-E71	King's Indian Defense: Karpov System	1. d4 Nf6 2. c4 g6 3. Nc3 Bg7 4. e4 d6 5. h3 0-0 6. Be3
+E71	King's Indian Defense: Karpov System	1. d4 Nf6 2. c4 g6 3. Nc3 Bg7 4. e4 d6 5. h3 O-O 6. Be3
 E71	King's Indian Defense: Makogonov Variation	1. d4 Nf6 2. c4 g6 3. Nc3 Bg7 4. e4 d6 5. h3
 E72	King's Indian Defense: Normal Variation, Deferred Fianchetto	1. d4 Nf6 2. c4 g6 3. Nc3 Bg7 4. e4 d6 5. g3
 E72	King's Indian Defense: Pomar System	1. d4 Nf6 2. c4 g6 3. Nc3 Bg7 4. e4 d6 5. g3 O-O 6. Bg2 e5 7. Nge2


### PR DESCRIPTION
Added the trendy Karpov system in KID (https://www.chesspublishing.com/content/9/feb20.htm) Called here by David Vigorito
Also fixed the categorization of E81 lines and added two ECOs that were missing (E57 and E88) which the lines can be found here: https://chessopenings.com/eco/