### PR TITLE
Added B07 line

### DIFF
--- a/b.tsv
+++ b/b.tsv
@@ -232,6 +232,7 @@ B06	Pterodactyl Defense: Western, Siroccopteryx	1. e4 g6 2. Nf3 Bg7 3. d4 c5 4. 
 B06	Rat Defense: Accelerated Gurgenidze	1. e4 g6 2. d4 d6 3. Nc3 c6
 B07	Czech Defense	1. e4 d6 2. d4 Nf6 3. Nc3 c6
 B07	King's Pawn Game: Maróczy Defense	1. e4 d6 2. d4 e5
+B07	Lion Defense	1. e4 d6 2. d4 Nf6 3. Nc3 Nbd7
 B07	Lion Defense: Anti-Philidor	1. e4 d6 2. d4 Nf6 3. Nc3 Nbd7 4. f4
 B07	Lion Defense: Anti-Philidor, Lion's Cave	1. e4 d6 2. d4 Nf6 3. Nc3 Nbd7 4. f4 e5
 B07	Lion Defense: Anti-Philidor, Lion's Cave, Lion Claw Gambit	1. e4 d6 2. d4 Nf6 3. Nc3 Nbd7 4. f4 e5 5. Nf3 exd4 6. Qxd4 c6 7. Bc4 d5


### PR DESCRIPTION
In this PR I'm adding the parent Lion defense (1. e4 d6 2. d4 Nf6 3. Nc3 Nbd7) This move order is also listed on chess.com (https://www.chess.com/openings/Lion-Defense). I noticed sub variations following these moves that also list Lion defense, but the parent opening isn't actually named, this PR fixes this by adding the parent name