### PR TITLE
Added C47 line

### DIFF
--- a/c.tsv
+++ b/c.tsv
@@ -776,6 +776,7 @@ C46	Three Knights Opening: Steinitz Defense	1. e4 e5 2. Nf3 Nc6 3. Nc3 g6
 C46	Three Knights Opening: Steinitz-Rosenthal Variation	1. e4 e5 2. Nf3 Nc6 3. Nc3 g6 4. d4 exd4 5. Nd5
 C46	Three Knights Opening: Winawer Defense	1. e4 e5 2. Nf3 Nc6 3. Nc3 f5
 C47	Four Knights Game	1. e4 e5 2. Nf3 Nc6 3. Nc3 Nf6
+C47	Four Knights Game: Giri Variation	1. e4 e5 2. Nf3 Nc6 3. Nc3 Nf6 4. h3
 C47	Four Knights Game: Glek System	1. e4 e5 2. Nf3 Nc6 3. Nc3 Nf6 4. g3
 C47	Four Knights Game: Glek System	1. e4 e5 2. Nf3 Nc6 3. Nc3 Nf6 4. g3 d5 5. exd5 Nxd5 6. Bg2 Nxc3 7. bxc3
 C47	Four Knights Game: Gunsberg Variation	1. e4 e5 2. Nf3 Nc6 3. Nc3 Nf6 4. a3


### PR DESCRIPTION
I added a trendy line in the 4 knights (4. h3 ECO C47) that seems to have been first popularized by Anish Giri https://www.chessgames.com/perl/chess.pl?pid=107252&playercomp=white&eco=C46, he had 3 games in 2014 scoring 2.5/3 with this variation and I think this is when the variation took off. Also IM Miodrag Perunovic acknowledges this idea started getting popularity with Giri as shown in this [video](https://www.youtube.com/watch?v=Z4Dmfsw7cfA). As a result, it makes sense to name this variation the "Giri Variation"