### PR TITLE
Replace endash with hyphen

### DIFF
--- a/e.tsv
+++ b/e.tsv
@@ -199,7 +199,7 @@ E43	Nimzo-Indian Defense: St. Petersburg Variation	1. d4 Nf6 2. c4 e6 3. Nc3 Bb4
 E43	Nimzo-Indian Defense: St. Petersburg Variation, with Ne4	1. d4 Nf6 2. c4 e6 3. Nc3 Bb4 4. e3 b6 5. Bd3 Bb7 6. Nf3 Ne4
 E44	Nimzo-Indian Defense: St. Petersburg Variation	1. d4 Nf6 2. c4 e6 3. Nc3 Bb4 4. e3 b6 5. Ne2
 E44	Nimzo-Indian Defense: St. Petersburg Variation, American Variation	1. d4 Nf6 2. c4 e6 3. Nc3 Bb4 4. e3 b6 5. Ne2 Ne4
-E44	Nimzo-Indian Defense: St. Petersburg Variation, Romanishin–Psakhis Variation	1. d4 Nf6 2. c4 e6 3. Nc3 Bb4 4. e3 b6 5. Ne2 c5 6. a3 Ba5
+E44	Nimzo-Indian Defense: St. Petersburg Variation, Romanishin-Psakhis Variation	1. d4 Nf6 2. c4 e6 3. Nc3 Bb4 4. e3 b6 5. Ne2 c5 6. a3 Ba5
 E45	Nimzo-Indian Defense: St. Petersburg Variation, Fischer Variation	1. d4 Nf6 2. c4 e6 3. Nc3 Bb4 4. e3 b6 5. Ne2 Ba6
 E46	Nimzo-Indian Defense: Normal Variation	1. d4 Nf6 2. c4 e6 3. Nc3 Bb4 4. e3 O-O
 E46	Nimzo-Indian Defense: Reshevsky Variation	1. d4 Nf6 2. c4 e6 3. Nc3 Bb4 4. e3 O-O 5. Ne2


### PR DESCRIPTION
This is the only occurrence of the endash. Typographically correct (name–name) but also the only place it's used. These all use hyphens:

```
Indian Defense: Paleface Attack, Blackmar-Diemer Gambit Deferred
Sicilian Defense: Richter-Rauzer Variation
Sicilian Defense: Smith-Morra Gambit
Rapport-Jobava System
```