### PR TITLE
Add fully developed Neo-Catalan continuation with 4.Bg2

### DIFF
--- a/a.tsv
+++ b/a.tsv
@@ -331,7 +331,7 @@ A13	English Opening: Agincourt Defense, Catalan Defense, Semi-Slav Defense	1. c4
 A13	English Opening: Agincourt Defense, Kurajica Defense	1. c4 e6 2. Nf3 d5 3. g3 c6
 A13	English Opening: Agincourt Defense, Tarrasch Defense	1. c4 e6 2. Nf3 d5 3. g3 Nf6 4. Bg2 c5 5. b3 Nc6 6. O-O Be7
 A13	English Opening: Agincourt Defense, Wimpy System	1. c4 e6 2. Nf3 Nf6 3. b3 d5 4. Bb2 c5 5. e3
-A13	English Opening: Neo-Catalan	1. c4 e6 2. Nf3 d5 3. g3 Nf6
+A13	English Opening: Neo-Catalan	1. c4 e6 2. Nf3 d5 3. g3 Nf6 4. Bg2
 A13	English Opening: Neo-Catalan Declined	1. c4 e6 2. Nf3 d5 3. g3 Nf6 4. Bg2 Be7
 A13	English Opening: Romanishin Gambit	1. c4 Nf6 2. Nf3 e6 3. g3 a6 4. Bg2 b5
 A14	English Opening: Agincourt Defense, Keres Defense	1. c4 e6 2. Nf3 d5 3. g3 Nf6 4. Bg2 Be7 5. O-O c5 6. cxd5 Nxd5 7. Nc3 Nc6


### PR DESCRIPTION
Added a Neo-Catalan continuation featuring 4.Bg2 to reflect the fully established kingside fianchetto setup.

The existing entry labels the Neo-Catalan structure after 3...Nf6, while this addition includes the natural continuation where White completes the Catalan-style development.