### PR TITLE
Add new variations to King's Indian and English openings

### DIFF
--- a/a.tsv
+++ b/a.tsv
@@ -258,6 +258,7 @@ A07	King's Indian Attack: Omega-Delta Gambit	1. Nf3 d5 2. g3 e5
 A07	King's Indian Attack: Pachman System	1. Nf3 d5 2. g3 g6 3. Bg2 Bg7 4. O-O e5 5. d3 Ne7
 A07	King's Indian Attack: Sicilian Variation	1. Nf3 d5 2. g3 c5
 A07	King's Indian Attack: Yugoslav Variation	1. Nf3 Nf6 2. g3 d5 3. Bg2 c6 4. O-O Bg4
+A07 King's Indian Attack: Yugoslav Variation 1. c4 e6 2. Nf3 d5 3. g3 Nf6 4. Bg2 b6 5. O-O
 A08	King's Indian Attack: French Variation	1. Nf3 d5 2. g3 c5 3. Bg2 Nc6
 A08	King's Indian Attack: Sicilian Variation	1. e4 e6 2. d3 d5 3. Nd2 Nf6 4. Ngf3 c5 5. g3 Nc6 6. Bg2 Be7 7. O-O O-O 8. Re1
 A08	King's Indian Attack: Sicilian Variation	1. Nf3 d5 2. g3 c5 3. Bg2
@@ -332,6 +333,7 @@ A13	English Opening: Agincourt Defense, Kurajica Defense	1. c4 e6 2. Nf3 d5 3. g
 A13	English Opening: Agincourt Defense, Tarrasch Defense	1. c4 e6 2. Nf3 d5 3. g3 Nf6 4. Bg2 c5 5. b3 Nc6 6. O-O Be7
 A13	English Opening: Agincourt Defense, Wimpy System	1. c4 e6 2. Nf3 Nf6 3. b3 d5 4. Bb2 c5 5. e3
 A13	English Opening: Neo-Catalan	1. c4 e6 2. Nf3 d5 3. g3 Nf6
+A13	English Opening: Neo-Catalan, Semi-Slav Defense	1. c4 e6 2. Nf3 d5 3. g3 Nf6 4. Bg2 c6
 A13	English Opening: Neo-Catalan Declined	1. c4 e6 2. Nf3 d5 3. g3 Nf6 4. Bg2 Be7
 A13	English Opening: Romanishin Gambit	1. c4 Nf6 2. Nf3 e6 3. g3 a6 4. Bg2 b5
 A14	English Opening: Agincourt Defense, Keres Defense	1. c4 e6 2. Nf3 d5 3. g3 Nf6 4. Bg2 Be7 5. O-O c5 6. cxd5 Nxd5 7. Nc3 Nc6


### PR DESCRIPTION
This PR adds additional Neo-Catalan continuations arising from English Opening move orders.

Changes included:

* Added a transpositional line where the Neo-Catalan setup reaches the King's Indian Attack: Yugoslav Variation after: `1. c4 e6 2. Nf3 d5 3. g3 Nf6 4. Bg2 b6 5. O-O`

Added a Neo-Catalan Semi-Slav continuation:
  1. c4 e6 2. Nf3 d5 3. g3 Nf6 4. Bg2 c6`

These additions help capture common transpositions and alternative continuations that lead to established opening structures through English Opening move orders.