### PR TITLE
Add Neo-Catalan transposition to King's Indian Attack: Yugoslav Varia…

### DIFF
--- a/a.tsv
+++ b/a.tsv
@@ -258,6 +258,7 @@ A07	King's Indian Attack: Omega-Delta Gambit	1. Nf3 d5 2. g3 e5
 A07	King's Indian Attack: Pachman System	1. Nf3 d5 2. g3 g6 3. Bg2 Bg7 4. O-O e5 5. d3 Ne7
 A07	King's Indian Attack: Sicilian Variation	1. Nf3 d5 2. g3 c5
 A07	King's Indian Attack: Yugoslav Variation	1. Nf3 Nf6 2. g3 d5 3. Bg2 c6 4. O-O Bg4
+A07	King's Indian Attack: Yugoslav Variation	1. c4 e6 2. Nf3 d5 3. g3 Nf6 4. Bg2 b6 5. O-O
 A08	King's Indian Attack: French Variation	1. Nf3 d5 2. g3 c5 3. Bg2 Nc6
 A08	King's Indian Attack: Sicilian Variation	1. e4 e6 2. d3 d5 3. Nd2 Nf6 4. Ngf3 c5 5. g3 Nc6 6. Bg2 Be7 7. O-O O-O 8. Re1
 A08	King's Indian Attack: Sicilian Variation	1. Nf3 d5 2. g3 c5 3. Bg2


### PR DESCRIPTION
This PR adds a transposition from the Neo-Catalan to the King's Indian Attack: Yugoslav Variation through the move order:

`1. c4 e6 2. Nf3 d5 3. g3 Nf6 4. Bg2 b6 5. O-O`

This helps cover an alternative English Opening move order leading to the same opening structure.