### PR TITLE
Added E01 Tarrasch defense line

### DIFF
--- a/e.tsv
+++ b/e.tsv
@@ -5,7 +5,8 @@ E00	Catalan Opening: Hungarian Gambit	1. d4 Nf6 2. c4 e6 3. g3 e5
 E00	Indian Defense	1. d4 Nf6 2. c4 e6 3. Qb3
 E00	Indian Defense: Devin Gambit	1. d4 Nf6 2. c4 e6 3. g4
 E00	Indian Defense: Seirawan Attack	1. d4 Nf6 2. c4 e6 3. Bg5
-E01	Catalan Opening: Closed	1. d4 Nf6 2. c4 e6 3. g3 d5 4. Bg2
+E01	Catalan Opening: Tarrasch Defense	1. d4 Nf6 2. c4 e6 3. g3 d5 4. Bg2 c5 5. Nf3 Nc6
+E04	Catalan Opening: Open Defense	1. d4 Nf6 2. c4 e6 3. g3 d5 4. Bg2 
 E02	Catalan Opening: Open Defense	1. d4 Nf6 2. c4 e6 3. g3 d5 4. Bg2 dxc4
 E03	Catalan Opening: Open Defense	1. d4 Nf6 2. c4 e6 3. g3 d5 4. Bg2 dxc4 5. Qa4+ Nbd7 6. Qxc4
 E03	Catalan Opening: Open Defense, Alekhine Variation	1. d4 Nf6 2. c4 e6 3. g3 d5 4. Bg2 dxc4 5. Qa4+ Nbd7 6. Qxc4 a6 7. Qc2

--- a/e.tsv
+++ b/e.tsv
@@ -5,8 +5,8 @@ E00	Catalan Opening: Hungarian Gambit	1. d4 Nf6 2. c4 e6 3. g3 e5
 E00	Indian Defense	1. d4 Nf6 2. c4 e6 3. Qb3
 E00	Indian Defense: Devin Gambit	1. d4 Nf6 2. c4 e6 3. g4
 E00	Indian Defense: Seirawan Attack	1. d4 Nf6 2. c4 e6 3. Bg5
+E01	Catalan Opening: Open Defense	1. d4 Nf6 2. c4 e6 3. g3 d5 4. Bg2
 E01	Catalan Opening: Tarrasch Defense	1. d4 Nf6 2. c4 e6 3. g3 d5 4. Bg2 c5 5. Nf3 Nc6
-E04	Catalan Opening: Open Defense	1. d4 Nf6 2. c4 e6 3. g3 d5 4. Bg2 
 E02	Catalan Opening: Open Defense	1. d4 Nf6 2. c4 e6 3. g3 d5 4. Bg2 dxc4
 E03	Catalan Opening: Open Defense	1. d4 Nf6 2. c4 e6 3. g3 d5 4. Bg2 dxc4 5. Qa4+ Nbd7 6. Qxc4
 E03	Catalan Opening: Open Defense, Alekhine Variation	1. d4 Nf6 2. c4 e6 3. g3 d5 4. Bg2 dxc4 5. Qa4+ Nbd7 6. Qxc4 a6 7. Qc2


### PR DESCRIPTION
I added the Catalan opening, Tarrasch defense line in this PR (source is here: https://chesstempo.com/game-database/opening/catalan-opening-open-defense-tarrasch-defense/329)
However, I don't think this suits ECO E04 as dxc4 hasn't been played yet (as a result I feel Open defense isn't a very suitable name as usually Catalan open positions are ones in which dxc4 has been played). As a result, I removed Open Defense and made this E01 eco instead (just calling it Catalan opening, Tarrasch defense)