### PR TITLE
Add a D31 line

### DIFF
--- a/d.tsv
+++ b/d.tsv
@@ -285,6 +285,7 @@ D31	Queen's Gambit Declined: Semi-Slav, Abrahams Variation	1. d4 d5 2. c4 e6 3. 
 D31	Queen's Gambit Declined: Semi-Slav, Junge Variation	1. d4 d5 2. c4 e6 3. Nf3 c6 4. Nc3 dxc4 5. a4 Bb4 6. e3 b5 7. Bd2 Qb6
 D31	Queen's Gambit Declined: Semi-Slav, Koomen Variation	1. d4 d5 2. c4 e6 3. Nc3 c6 4. Nf3 dxc4 5. e3 b5 6. a4 Bb4 7. Bd2 Qe7
 D31	Semi-Slav Defense: Accelerated Move Order	1. d4 d5 2. c4 e6 3. Nc3 c6
+D31	Semi-Slav Defense: Anti-Noteboom, Stonewall Variation	1. d4 d5 2. c4 e6 3. Nc3 c6 4. e3 f5
 D31	Semi-Slav Defense: Anti-Noteboom, Stonewall Variation, Portisch Gambit	1. d4 d5 2. c4 e6 3. Nc3 c6 4. e3 f5 5. g4
 D31	Semi-Slav Defense: Gunderam Gambit	1. d4 d5 2. c4 e6 3. Nc3 c6 4. e4 dxe4 5. f3
 D31	Semi-Slav Defense: Marshall Gambit	1. d4 d5 2. c4 e6 3. Nc3 c6 4. e4


### PR DESCRIPTION
I'm adding the parent line to the Portisch Gambit (which is listed on lichess as D31 Semi-Slav Defense: Anti-Noteboom, Stonewall Variation, Portisch Gambit). I noticed there's no line named "Semi-Slav Defense: Anti-Noteboom, Stonewall Variation" (which should just be 1. d4 d5 2. c4 e6 3. Nc3 c6 4. e3 f5 without g4 (with g4 being the Portisch Gambit)). However, there is a child line with this name, which is a little weird). This PR fixes this by adding the parent line