### PR TITLE
Update names of Queen's Gambit lines

### DIFF
--- a/d.tsv
+++ b/d.tsv
@@ -124,43 +124,43 @@ D05	Rubinstein Opening: Classical Defense	1. d4 Nf6 2. Nf3 e6 3. e3 c5 4. Bd3 d5
 D05	Rubinstein Opening: Semi-Slav Defense	1. d4 d5 2. Nf3 Nf6 3. e3 e6 4. Bd3 Bd6 5. O-O O-O 6. b3 Nbd7 7. Bb2
 D05	Rubinstein Opening: Semi-Slav Defense	1. d4 d5 2. Nf3 Nf6 3. e3 e6 4. Bd3 Bd6 5. O-O O-O 6. b3 Nbd7 7. Bb2 c6
 D05	Rubinstein Opening: Semi-Slav Defense	1. d4 d5 2. Nf3 Nf6 3. e3 e6 4. Bd3 Bd6 5. O-O O-O 6. b3 Nbd7 7. Bb2 c6 8. Nbd2
+D06	Austrian Defense, Salvio Countergambit	1. d4 d5 2. c4 c5 3. dxc5 d4
+D06	Austrian Defense	1. d4 d5 2. c4 c5
+D06	Austrian Defense, Gusev Countergambit	1. d4 d5 2. c4 c5 3. cxd5 Nf6
+D06	Austrian Defense, Haberditz Variation	1. d4 d5 2. c4 c5 3. cxd5 Nf6 4. e4 Nxe4 5. dxc5 Qa5+
+D06	Baltic Defense	1. d4 d5 2. c4 Bf5
+D06	Baltic Defense, Argentinian Gambit	1. d4 d5 2. c4 Bf5 3. cxd5 Bxb1 4. Qa4+ c6 5. dxc6 Nxc6
+D06	Baltic Defense, Pseudo-Chigorin	1. d4 d5 2. c4 Bf5 3. Nc3 e6 4. Nf3 Nc6
+D06	Baltic Defense, Queen Attack	1. d4 d5 2. c4 Bf5 3. Qb3
+D06	Baltic Defense, Queen Attack Deferred	1. d4 d5 2. c4 Bf5 3. Nc3 e6 4. Qb3
+D06	Marshall Defense	1. d4 d5 2. c4 Nf6
+D06	Marshall Defense, Tan Gambit	1. d4 d5 2. c4 Nf6 3. cxd5 c6
 D06	Queen's Gambit	1. d4 d5 2. c4
-D06	Queen's Gambit Refused: Austrian Attack, Salvio Countergambit	1. d4 d5 2. c4 c5 3. dxc5 d4
-D06	Queen's Gambit Refused: Austrian Defense	1. d4 d5 2. c4 c5
-D06	Queen's Gambit Refused: Austrian Defense, Gusev Countergambit	1. d4 d5 2. c4 c5 3. cxd5 Nf6
-D06	Queen's Gambit Refused: Austrian Defense, Haberditz Variation	1. d4 d5 2. c4 c5 3. cxd5 Nf6 4. e4 Nxe4 5. dxc5 Qa5+
-D06	Queen's Gambit Refused: Baltic Defense	1. d4 d5 2. c4 Bf5
-D06	Queen's Gambit Refused: Baltic Defense, Argentinian Gambit	1. d4 d5 2. c4 Bf5 3. cxd5 Bxb1 4. Qa4+ c6 5. dxc6 Nxc6
-D06	Queen's Gambit Refused: Baltic Defense, Pseudo-Chigorin	1. d4 d5 2. c4 Bf5 3. Nc3 e6 4. Nf3 Nc6
-D06	Queen's Gambit Refused: Baltic Defense, Queen Attack	1. d4 d5 2. c4 Bf5 3. Qb3
-D06	Queen's Gambit Refused: Baltic Defense, Queen Attack Deferred	1. d4 d5 2. c4 Bf5 3. Nc3 e6 4. Qb3
-D06	Queen's Gambit Refused: Marshall Defense	1. d4 d5 2. c4 Nf6
-D06	Queen's Gambit Refused: Marshall Defense, Tan Gambit	1. d4 d5 2. c4 Nf6 3. cxd5 c6
-D06	Queen's Gambit Refused: Zilbermints Gambit	1. d4 d5 2. c4 b5
-D07	Queen's Gambit Refused: Chigorin Defense	1. d4 d5 2. c4 Nc6
-D07	Queen's Gambit Refused: Chigorin Defense	1. d4 d5 2. c4 Nc6 3. Nc3
-D07	Queen's Gambit Refused: Chigorin Defense	1. d4 d5 2. c4 Nc6 3. Nc3 dxc4
-D07	Queen's Gambit Refused: Chigorin Defense, Exchange Variation	1. d4 d5 2. c4 Nc6 3. cxd5 Qxd5
-D07	Queen's Gambit Refused: Chigorin Defense, Exchange Variation, Costa's Line	1. d4 d5 2. c4 Nc6 3. cxd5 Qxd5 4. e3 e5 5. Nc3 Bb4 6. Bd2 Bxc3 7. Bxc3 exd4 8. Ne2
-D07	Queen's Gambit Refused: Chigorin Defense, Janowski Variation	1. d4 d5 2. c4 Nc6 3. Nc3 dxc4 4. Nf3
-D07	Queen's Gambit Refused: Chigorin Defense, Lazard Gambit	1. d4 d5 2. c4 Nc6 3. Nf3 e5
-D07	Queen's Gambit Refused: Chigorin Defense, Main Line	1. d4 d5 2. c4 Nc6 3. Nf3 Bg4
-D07	Queen's Gambit Refused: Chigorin Defense, Main Line, Alekhine Variation	1. d4 d5 2. c4 Nc6 3. Nf3 Bg4 4. Qa4
-D07	Queen's Gambit Refused: Chigorin Defense, Modern Gambit	1. d4 d5 2. c4 Nc6 3. Nc3 dxc4 4. Nf3 Nf6
-D07	Queen's Gambit Refused: Chigorin Defense, Tartakower Gambit	1. d4 d5 2. c4 Nc6 3. Nc3 e5
-D08	Queen's Gambit Refused: Albin Countergambit	1. d4 d5 2. c4 e5
-D08	Queen's Gambit Refused: Albin Countergambit, Balogh Variation	1. d4 d5 2. c4 e5 3. dxe5 d4 4. Nf3 Nc6 5. Nbd2 Qe7
-D08	Queen's Gambit Refused: Albin Countergambit, Janowski Variation	1. d4 d5 2. c4 e5 3. dxe5 d4 4. Nf3 Nc6 5. Nbd2 f6
-D08	Queen's Gambit Refused: Albin Countergambit, Krenosz Variation	1. d4 d5 2. c4 e5 3. dxe5 d4 4. Nf3 Nc6 5. Nbd2 Bg4 6. h3 Bxf3 7. Nxf3 Bb4+ 8. Bd2 Qe7
-D08	Queen's Gambit Refused: Albin Countergambit, Lasker Trap	1. d4 d5 2. c4 e5 3. dxe5 d4 4. e3 Bb4+ 5. Bd2 dxe3
-D08	Queen's Gambit Refused: Albin Countergambit, Modern Line	1. d4 d5 2. c4 e5 3. dxe5 d4 4. Nf3 Nc6 5. Nbd2
-D08	Queen's Gambit Refused: Albin Countergambit, Normal Line	1. d4 d5 2. c4 e5 3. dxe5 d4 4. Nf3
-D08	Queen's Gambit Refused: Albin Countergambit, Spassky Variation	1. d4 d5 2. c4 e5 3. dxe5 d4 4. e4
-D08	Queen's Gambit Refused: Albin Countergambit, Tartakower Defense	1. d4 d5 2. c4 e5 3. dxe5 d4 4. Nf3 c5
-D09	Queen's Gambit Refused: Albin Countergambit, Fianchetto Variation	1. d4 d5 2. c4 e5 3. dxe5 d4 4. Nf3 Nc6 5. g3
-D09	Queen's Gambit Refused: Albin Countergambit, Fianchetto Variation, Be6 Line	1. d4 d5 2. c4 e5 3. dxe5 d4 4. Nf3 Nc6 5. g3 Be6
-D09	Queen's Gambit Refused: Albin Countergambit, Fianchetto Variation, Bf5 Line	1. d4 d5 2. c4 e5 3. dxe5 d4 4. Nf3 Nc6 5. g3 Bf5
-D09	Queen's Gambit Refused: Albin Countergambit, Fianchetto Variation, Bg4 Line	1. d4 d5 2. c4 e5 3. dxe5 d4 4. Nf3 Nc6 5. g3 Bg4
+D06	Zilbermints Gambit	1. d4 d5 2. c4 b5
+D07	Chigorin Defense	1. d4 d5 2. c4 Nc6
+D07	Chigorin Defense	1. d4 d5 2. c4 Nc6 3. Nc3
+D07	Chigorin Defense	1. d4 d5 2. c4 Nc6 3. Nc3 dxc4
+D07	Chigorin Defense, Exchange Variation	1. d4 d5 2. c4 Nc6 3. cxd5 Qxd5
+D07	Chigorin Defense, Exchange Variation, Costa's Line	1. d4 d5 2. c4 Nc6 3. cxd5 Qxd5 4. e3 e5 5. Nc3 Bb4 6. Bd2 Bxc3 7. Bxc3 exd4 8. Ne2
+D07	Chigorin Defense, Janowski Variation	1. d4 d5 2. c4 Nc6 3. Nc3 dxc4 4. Nf3
+D07	Chigorin Defense, Lazard Gambit	1. d4 d5 2. c4 Nc6 3. Nf3 e5
+D07	Chigorin Defense, Main Line	1. d4 d5 2. c4 Nc6 3. Nf3 Bg4
+D07	Chigorin Defense, Main Line, Alekhine Variation	1. d4 d5 2. c4 Nc6 3. Nf3 Bg4 4. Qa4
+D07	Chigorin Defense, Modern Gambit	1. d4 d5 2. c4 Nc6 3. Nc3 dxc4 4. Nf3 Nf6
+D07	Chigorin Defense, Tartakower Gambit	1. d4 d5 2. c4 Nc6 3. Nc3 e5
+D08	Albin Countergambit	1. d4 d5 2. c4 e5
+D08	Albin Countergambit, Balogh Variation	1. d4 d5 2. c4 e5 3. dxe5 d4 4. Nf3 Nc6 5. Nbd2 Qe7
+D08	Albin Countergambit, Janowski Variation	1. d4 d5 2. c4 e5 3. dxe5 d4 4. Nf3 Nc6 5. Nbd2 f6
+D08	Albin Countergambit, Krenosz Variation	1. d4 d5 2. c4 e5 3. dxe5 d4 4. Nf3 Nc6 5. Nbd2 Bg4 6. h3 Bxf3 7. Nxf3 Bb4+ 8. Bd2 Qe7
+D08	Albin Countergambit, Lasker Trap	1. d4 d5 2. c4 e5 3. dxe5 d4 4. e3 Bb4+ 5. Bd2 dxe3
+D08	Albin Countergambit, Modern Line	1. d4 d5 2. c4 e5 3. dxe5 d4 4. Nf3 Nc6 5. Nbd2
+D08	Albin Countergambit, Normal Line	1. d4 d5 2. c4 e5 3. dxe5 d4 4. Nf3
+D08	Albin Countergambit, Spassky Variation	1. d4 d5 2. c4 e5 3. dxe5 d4 4. e4
+D08	Albin Countergambit, Tartakower Defense	1. d4 d5 2. c4 e5 3. dxe5 d4 4. Nf3 c5
+D09	Albin Countergambit, Fianchetto Variation	1. d4 d5 2. c4 e5 3. dxe5 d4 4. Nf3 Nc6 5. g3
+D09	Albin Countergambit, Fianchetto Variation, Be6 Line	1. d4 d5 2. c4 e5 3. dxe5 d4 4. Nf3 Nc6 5. g3 Be6
+D09	Albin Countergambit, Fianchetto Variation, Bf5 Line	1. d4 d5 2. c4 e5 3. dxe5 d4 4. Nf3 Nc6 5. g3 Bf5
+D09	Albin Countergambit, Fianchetto Variation, Bg4 Line	1. d4 d5 2. c4 e5 3. dxe5 d4 4. Nf3 Nc6 5. g3 Bg4
 D10	Slav Defense	1. d4 d5 2. c4 c6
 D10	Slav Defense	1. d4 d5 2. c4 c6 3. Nc3
 D10	Slav Defense	1. d4 d5 2. c4 c6 3. Nc3 dxc4

--- a/d.tsv
+++ b/d.tsv
@@ -125,42 +125,42 @@ D05	Rubinstein Opening: Semi-Slav Defense	1. d4 d5 2. Nf3 Nf6 3. e3 e6 4. Bd3 Bd
 D05	Rubinstein Opening: Semi-Slav Defense	1. d4 d5 2. Nf3 Nf6 3. e3 e6 4. Bd3 Bd6 5. O-O O-O 6. b3 Nbd7 7. Bb2 c6
 D05	Rubinstein Opening: Semi-Slav Defense	1. d4 d5 2. Nf3 Nf6 3. e3 e6 4. Bd3 Bd6 5. O-O O-O 6. b3 Nbd7 7. Bb2 c6 8. Nbd2
 D06	Queen's Gambit	1. d4 d5 2. c4
-D06	Queen's Gambit Declined: Austrian Attack, Salvio Countergambit	1. d4 d5 2. c4 c5 3. dxc5 d4
-D06	Queen's Gambit Declined: Austrian Defense	1. d4 d5 2. c4 c5
-D06	Queen's Gambit Declined: Austrian Defense, Gusev Countergambit	1. d4 d5 2. c4 c5 3. cxd5 Nf6
-D06	Queen's Gambit Declined: Austrian Defense, Haberditz Variation	1. d4 d5 2. c4 c5 3. cxd5 Nf6 4. e4 Nxe4 5. dxc5 Qa5+
-D06	Queen's Gambit Declined: Baltic Defense	1. d4 d5 2. c4 Bf5
-D06	Queen's Gambit Declined: Baltic Defense, Argentinian Gambit	1. d4 d5 2. c4 Bf5 3. cxd5 Bxb1 4. Qa4+ c6 5. dxc6 Nxc6
-D06	Queen's Gambit Declined: Baltic Defense, Pseudo-Chigorin	1. d4 d5 2. c4 Bf5 3. Nc3 e6 4. Nf3 Nc6
-D06	Queen's Gambit Declined: Baltic Defense, Queen Attack	1. d4 d5 2. c4 Bf5 3. Qb3
-D06	Queen's Gambit Declined: Baltic Defense, Queen Attack Deferred	1. d4 d5 2. c4 Bf5 3. Nc3 e6 4. Qb3
-D06	Queen's Gambit Declined: Marshall Defense	1. d4 d5 2. c4 Nf6
-D06	Queen's Gambit Declined: Marshall Defense, Tan Gambit	1. d4 d5 2. c4 Nf6 3. cxd5 c6
-D06	Queen's Gambit Declined: Zilbermints Gambit	1. d4 d5 2. c4 b5
-D07	Queen's Gambit Declined: Chigorin Defense	1. d4 d5 2. c4 Nc6
-D07	Queen's Gambit Declined: Chigorin Defense	1. d4 d5 2. c4 Nc6 3. Nc3
-D07	Queen's Gambit Declined: Chigorin Defense	1. d4 d5 2. c4 Nc6 3. Nc3 dxc4
-D07	Queen's Gambit Declined: Chigorin Defense, Exchange Variation	1. d4 d5 2. c4 Nc6 3. cxd5 Qxd5
-D07	Queen's Gambit Declined: Chigorin Defense, Exchange Variation, Costa's Line	1. d4 d5 2. c4 Nc6 3. cxd5 Qxd5 4. e3 e5 5. Nc3 Bb4 6. Bd2 Bxc3 7. Bxc3 exd4 8. Ne2
-D07	Queen's Gambit Declined: Chigorin Defense, Janowski Variation	1. d4 d5 2. c4 Nc6 3. Nc3 dxc4 4. Nf3
-D07	Queen's Gambit Declined: Chigorin Defense, Lazard Gambit	1. d4 d5 2. c4 Nc6 3. Nf3 e5
-D07	Queen's Gambit Declined: Chigorin Defense, Main Line	1. d4 d5 2. c4 Nc6 3. Nf3 Bg4
-D07	Queen's Gambit Declined: Chigorin Defense, Main Line, Alekhine Variation	1. d4 d5 2. c4 Nc6 3. Nf3 Bg4 4. Qa4
-D07	Queen's Gambit Declined: Chigorin Defense, Modern Gambit	1. d4 d5 2. c4 Nc6 3. Nc3 dxc4 4. Nf3 Nf6
-D07	Queen's Gambit Declined: Chigorin Defense, Tartakower Gambit	1. d4 d5 2. c4 Nc6 3. Nc3 e5
-D08	Queen's Gambit Declined: Albin Countergambit	1. d4 d5 2. c4 e5
-D08	Queen's Gambit Declined: Albin Countergambit, Balogh Variation	1. d4 d5 2. c4 e5 3. dxe5 d4 4. Nf3 Nc6 5. Nbd2 Qe7
-D08	Queen's Gambit Declined: Albin Countergambit, Janowski Variation	1. d4 d5 2. c4 e5 3. dxe5 d4 4. Nf3 Nc6 5. Nbd2 f6
-D08	Queen's Gambit Declined: Albin Countergambit, Krenosz Variation	1. d4 d5 2. c4 e5 3. dxe5 d4 4. Nf3 Nc6 5. Nbd2 Bg4 6. h3 Bxf3 7. Nxf3 Bb4+ 8. Bd2 Qe7
-D08	Queen's Gambit Declined: Albin Countergambit, Lasker Trap	1. d4 d5 2. c4 e5 3. dxe5 d4 4. e3 Bb4+ 5. Bd2 dxe3
-D08	Queen's Gambit Declined: Albin Countergambit, Modern Line	1. d4 d5 2. c4 e5 3. dxe5 d4 4. Nf3 Nc6 5. Nbd2
-D08	Queen's Gambit Declined: Albin Countergambit, Normal Line	1. d4 d5 2. c4 e5 3. dxe5 d4 4. Nf3
-D08	Queen's Gambit Declined: Albin Countergambit, Spassky Variation	1. d4 d5 2. c4 e5 3. dxe5 d4 4. e4
-D08	Queen's Gambit Declined: Albin Countergambit, Tartakower Defense	1. d4 d5 2. c4 e5 3. dxe5 d4 4. Nf3 c5
-D09	Queen's Gambit Declined: Albin Countergambit, Fianchetto Variation	1. d4 d5 2. c4 e5 3. dxe5 d4 4. Nf3 Nc6 5. g3
-D09	Queen's Gambit Declined: Albin Countergambit, Fianchetto Variation, Be6 Line	1. d4 d5 2. c4 e5 3. dxe5 d4 4. Nf3 Nc6 5. g3 Be6
-D09	Queen's Gambit Declined: Albin Countergambit, Fianchetto Variation, Bf5 Line	1. d4 d5 2. c4 e5 3. dxe5 d4 4. Nf3 Nc6 5. g3 Bf5
-D09	Queen's Gambit Declined: Albin Countergambit, Fianchetto Variation, Bg4 Line	1. d4 d5 2. c4 e5 3. dxe5 d4 4. Nf3 Nc6 5. g3 Bg4
+D06	Queen's Gambit Refused: Austrian Attack, Salvio Countergambit	1. d4 d5 2. c4 c5 3. dxc5 d4
+D06	Queen's Gambit Refused: Austrian Defense	1. d4 d5 2. c4 c5
+D06	Queen's Gambit Refused: Austrian Defense, Gusev Countergambit	1. d4 d5 2. c4 c5 3. cxd5 Nf6
+D06	Queen's Gambit Refused: Austrian Defense, Haberditz Variation	1. d4 d5 2. c4 c5 3. cxd5 Nf6 4. e4 Nxe4 5. dxc5 Qa5+
+D06	Queen's Gambit Refused: Baltic Defense	1. d4 d5 2. c4 Bf5
+D06	Queen's Gambit Refused: Baltic Defense, Argentinian Gambit	1. d4 d5 2. c4 Bf5 3. cxd5 Bxb1 4. Qa4+ c6 5. dxc6 Nxc6
+D06	Queen's Gambit Refused: Baltic Defense, Pseudo-Chigorin	1. d4 d5 2. c4 Bf5 3. Nc3 e6 4. Nf3 Nc6
+D06	Queen's Gambit Refused: Baltic Defense, Queen Attack	1. d4 d5 2. c4 Bf5 3. Qb3
+D06	Queen's Gambit Refused: Baltic Defense, Queen Attack Deferred	1. d4 d5 2. c4 Bf5 3. Nc3 e6 4. Qb3
+D06	Queen's Gambit Refused: Marshall Defense	1. d4 d5 2. c4 Nf6
+D06	Queen's Gambit Refused: Marshall Defense, Tan Gambit	1. d4 d5 2. c4 Nf6 3. cxd5 c6
+D06	Queen's Gambit Refused: Zilbermints Gambit	1. d4 d5 2. c4 b5
+D07	Queen's Gambit Refused: Chigorin Defense	1. d4 d5 2. c4 Nc6
+D07	Queen's Gambit Refused: Chigorin Defense	1. d4 d5 2. c4 Nc6 3. Nc3
+D07	Queen's Gambit Refused: Chigorin Defense	1. d4 d5 2. c4 Nc6 3. Nc3 dxc4
+D07	Queen's Gambit Refused: Chigorin Defense, Exchange Variation	1. d4 d5 2. c4 Nc6 3. cxd5 Qxd5
+D07	Queen's Gambit Refused: Chigorin Defense, Exchange Variation, Costa's Line	1. d4 d5 2. c4 Nc6 3. cxd5 Qxd5 4. e3 e5 5. Nc3 Bb4 6. Bd2 Bxc3 7. Bxc3 exd4 8. Ne2
+D07	Queen's Gambit Refused: Chigorin Defense, Janowski Variation	1. d4 d5 2. c4 Nc6 3. Nc3 dxc4 4. Nf3
+D07	Queen's Gambit Refused: Chigorin Defense, Lazard Gambit	1. d4 d5 2. c4 Nc6 3. Nf3 e5
+D07	Queen's Gambit Refused: Chigorin Defense, Main Line	1. d4 d5 2. c4 Nc6 3. Nf3 Bg4
+D07	Queen's Gambit Refused: Chigorin Defense, Main Line, Alekhine Variation	1. d4 d5 2. c4 Nc6 3. Nf3 Bg4 4. Qa4
+D07	Queen's Gambit Refused: Chigorin Defense, Modern Gambit	1. d4 d5 2. c4 Nc6 3. Nc3 dxc4 4. Nf3 Nf6
+D07	Queen's Gambit Refused: Chigorin Defense, Tartakower Gambit	1. d4 d5 2. c4 Nc6 3. Nc3 e5
+D08	Queen's Gambit Refused: Albin Countergambit	1. d4 d5 2. c4 e5
+D08	Queen's Gambit Refused: Albin Countergambit, Balogh Variation	1. d4 d5 2. c4 e5 3. dxe5 d4 4. Nf3 Nc6 5. Nbd2 Qe7
+D08	Queen's Gambit Refused: Albin Countergambit, Janowski Variation	1. d4 d5 2. c4 e5 3. dxe5 d4 4. Nf3 Nc6 5. Nbd2 f6
+D08	Queen's Gambit Refused: Albin Countergambit, Krenosz Variation	1. d4 d5 2. c4 e5 3. dxe5 d4 4. Nf3 Nc6 5. Nbd2 Bg4 6. h3 Bxf3 7. Nxf3 Bb4+ 8. Bd2 Qe7
+D08	Queen's Gambit Refused: Albin Countergambit, Lasker Trap	1. d4 d5 2. c4 e5 3. dxe5 d4 4. e3 Bb4+ 5. Bd2 dxe3
+D08	Queen's Gambit Refused: Albin Countergambit, Modern Line	1. d4 d5 2. c4 e5 3. dxe5 d4 4. Nf3 Nc6 5. Nbd2
+D08	Queen's Gambit Refused: Albin Countergambit, Normal Line	1. d4 d5 2. c4 e5 3. dxe5 d4 4. Nf3
+D08	Queen's Gambit Refused: Albin Countergambit, Spassky Variation	1. d4 d5 2. c4 e5 3. dxe5 d4 4. e4
+D08	Queen's Gambit Refused: Albin Countergambit, Tartakower Defense	1. d4 d5 2. c4 e5 3. dxe5 d4 4. Nf3 c5
+D09	Queen's Gambit Refused: Albin Countergambit, Fianchetto Variation	1. d4 d5 2. c4 e5 3. dxe5 d4 4. Nf3 Nc6 5. g3
+D09	Queen's Gambit Refused: Albin Countergambit, Fianchetto Variation, Be6 Line	1. d4 d5 2. c4 e5 3. dxe5 d4 4. Nf3 Nc6 5. g3 Be6
+D09	Queen's Gambit Refused: Albin Countergambit, Fianchetto Variation, Bf5 Line	1. d4 d5 2. c4 e5 3. dxe5 d4 4. Nf3 Nc6 5. g3 Bf5
+D09	Queen's Gambit Refused: Albin Countergambit, Fianchetto Variation, Bg4 Line	1. d4 d5 2. c4 e5 3. dxe5 d4 4. Nf3 Nc6 5. g3 Bg4
 D10	Slav Defense	1. d4 d5 2. c4 c6
 D10	Slav Defense	1. d4 d5 2. c4 c6 3. Nc3
 D10	Slav Defense	1. d4 d5 2. c4 c6 3. Nc3 dxc4

--- a/d.tsv
+++ b/d.tsv
@@ -124,10 +124,10 @@ D05	Rubinstein Opening: Classical Defense	1. d4 Nf6 2. Nf3 e6 3. e3 c5 4. Bd3 d5
 D05	Rubinstein Opening: Semi-Slav Defense	1. d4 d5 2. Nf3 Nf6 3. e3 e6 4. Bd3 Bd6 5. O-O O-O 6. b3 Nbd7 7. Bb2
 D05	Rubinstein Opening: Semi-Slav Defense	1. d4 d5 2. Nf3 Nf6 3. e3 e6 4. Bd3 Bd6 5. O-O O-O 6. b3 Nbd7 7. Bb2 c6
 D05	Rubinstein Opening: Semi-Slav Defense	1. d4 d5 2. Nf3 Nf6 3. e3 e6 4. Bd3 Bd6 5. O-O O-O 6. b3 Nbd7 7. Bb2 c6 8. Nbd2
-D06	Austrian Defense, Salvio Countergambit	1. d4 d5 2. c4 c5 3. dxc5 d4
 D06	Austrian Defense	1. d4 d5 2. c4 c5
 D06	Austrian Defense, Gusev Countergambit	1. d4 d5 2. c4 c5 3. cxd5 Nf6
 D06	Austrian Defense, Haberditz Variation	1. d4 d5 2. c4 c5 3. cxd5 Nf6 4. e4 Nxe4 5. dxc5 Qa5+
+D06	Austrian Defense, Salvio Countergambit	1. d4 d5 2. c4 c5 3. dxc5 d4
 D06	Baltic Defense	1. d4 d5 2. c4 Bf5
 D06	Baltic Defense, Argentinian Gambit	1. d4 d5 2. c4 Bf5 3. cxd5 Bxb1 4. Qa4+ c6 5. dxc6 Nxc6
 D06	Baltic Defense, Pseudo-Chigorin	1. d4 d5 2. c4 Bf5 3. Nc3 e6 4. Nf3 Nc6


### PR DESCRIPTION
I updated the names of the D06-D09 lines to "Queen's Gambit Refused" instead of "Queen's Gambit Accepted" 
Sources are here:
https://chesstempo.com/game-database/opening/queens-gambit-refused-austrian-defense/1772
https://chesstempo.com/game-database/opening/queens-gambit-refused-chigorin-defense/1783
And more lines on chesstempo.
I feel the name of "Queen's gambit declined" only makes sense for the lines beginning with 1. d4 d5 2. c4 e6 as that's what almost everyone refers to as QGD. To avoid confusion, the lines in which Black doesn't play 2...e6 or 2...c6 to decline the Queen's gambit are named "Queen's gambit refused"
