### PR TITLE
Add some A41 lines

### DIFF
--- a/a.tsv
+++ b/a.tsv
@@ -535,7 +535,7 @@ A41	Modern Defense	1. d4 g6 2. c4 Bg7 3. Nc3 d6
 A41	Modern Defense: Neo-Modern Defense	1. d4 g6 2. c4 Bg7 3. e4 e5
 A41	Old Indian Defense	1. d4 d6 2. c4
 A41	Queen's Pawn Game	1. d4 d6
-A41	Queen's Pawn Game: Rossolimo Defense	1. d4 d6 2. Nf3 g6
+A41	Queen's Pawn Game: Rossolimo Variation	1. d4 d6 2. Nf3 g6
 A41	Rat Defense: English Rat	1. d4 d6 2. c4 e5
 A41	Rat Defense: English Rat, Lisbon Gambit	1. d4 d6 2. c4 e5 3. dxe5 Nc6
 A41	Rat Defense: English Rat, Pounds Gambit	1. d4 d6 2. c4 e5 3. dxe5 Be6

--- a/a.tsv
+++ b/a.tsv
@@ -535,6 +535,7 @@ A41	Modern Defense	1. d4 g6 2. c4 Bg7 3. Nc3 d6
 A41	Modern Defense: Neo-Modern Defense	1. d4 g6 2. c4 Bg7 3. e4 e5
 A41	Old Indian Defense	1. d4 d6 2. c4
 A41	Queen's Pawn Game	1. d4 d6
+A41	Queen's Pawn Game: Rossolimo Defense	1. d4 d6 2. Nf3 g6
 A41	Rat Defense: English Rat	1. d4 d6 2. c4 e5
 A41	Rat Defense: English Rat, Lisbon Gambit	1. d4 d6 2. c4 e5 3. dxe5 Nc6
 A41	Rat Defense: English Rat, Pounds Gambit	1. d4 d6 2. c4 e5 3. dxe5 Be6

--- a/a.tsv
+++ b/a.tsv
@@ -539,7 +539,7 @@ A41	Queen's Pawn Game: Rossolimo Variation	1. d4 d6 2. Nf3 g6
 A41	Rat Defense: English Rat	1. d4 d6 2. c4 e5
 A41	Rat Defense: English Rat, Lisbon Gambit	1. d4 d6 2. c4 e5 3. dxe5 Nc6
 A41	Rat Defense: English Rat, Pounds Gambit	1. d4 d6 2. c4 e5 3. dxe5 Be6
-A41	Robatsch Defense	1. d4 d6 2. Nf3 g6 3. c4 Bg7 4. e4 Bg4
+A41	Robatsch Defense: Rossolimo Variation	1. d4 d6 2. Nf3 g6 3. c4 Bg7 4. e4 Bg4
 A41	Wade Defense	1. d4 d6 2. Nf3 Bg4
 A41	Zukertort Opening: Wade Defense, Chigorin Plan	1. d4 d6 2. Nf3 Bg4 3. c4 Nd7 4. Qb3 Rb8
 A42	Modern Defense: Averbakh System	1. d4 g6 2. c4 Bg7 3. Nc3 d6 4. e4


### PR DESCRIPTION
Added Queen's pawn game: Rossolimo Variation:
Source: https://www.chess.com/openings/Queens-Pawn-Opening-Rossolimo-Variation

Also updated name of "Robatsch defense" which is a general name for 1. e4 g6 openings to a more specific Robatsch defense: Rossolimo Variation:
Source: https://www.365chess.com/eco/A41_Robatsch_defence_Rossolimo_variation